### PR TITLE
Spread out landing page graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,8 +81,8 @@
             radius: opts.radius ?? randomBetween(10, 26),
             pulseOffset: Math.random() * Math.PI * 2,
           };
-          node.x = opts.x ?? width / 2 + jitter(width * 0.24);
-          node.y = opts.y ?? height / 2 + jitter(height * 0.24);
+          node.x = opts.x ?? width / 2 + jitter(width * 0.35);
+          node.y = opts.y ?? height / 2 + jitter(height * 0.35);
           node.vx = 0;
           node.vy = 0;
           nodes.push(node);
@@ -137,13 +137,13 @@
             d3
               .forceLink(links)
               .id((d) => d.id)
-              .distance(() => randomBetween(34, 62))
-              .strength(0.16)
+              .distance(() => randomBetween(84, 140))
+              .strength(0.12)
           )
-          .force('charge', d3.forceManyBody().strength(-60))
-          .force('collide', d3.forceCollide().radius((d) => d.radius + 4).iterations(3))
-          .force('x', d3.forceX(() => width / 2).strength(0.024))
-          .force('y', d3.forceY(() => height / 2).strength(0.024))
+          .force('charge', d3.forceManyBody().strength(-120))
+          .force('collide', d3.forceCollide().radius((d) => d.radius + 8).iterations(3))
+          .force('x', d3.forceX(() => width / 2).strength(0.014))
+          .force('y', d3.forceY(() => height / 2).strength(0.014))
           .velocityDecay(0.58)
           .alphaDecay(0.04)
           .on('tick', ticked);


### PR DESCRIPTION
## Summary
- widen the initial node placement and tweak force simulation physics so the landing page graph appears more spread out

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fe264e78a8832bba9a423252c9a8ae