### PR TITLE
Slow down landing page network animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,8 +63,8 @@
     // Super-fast continuous rotation around two axes
     let angleX = 0;
     let angleY = 0;
-    let rotationSpeedX = 0.05; // X-axis speed
-    let rotationSpeedY = 0.04; // Y-axis speed
+    let rotationSpeedX = 0.005; // X-axis speed
+    let rotationSpeedY = 0.004; // Y-axis speed
 
     // Function to modulate network geometry dynamically
     function modulateNetwork() {


### PR DESCRIPTION
## Summary
- reduce the X and Y rotation speeds for the landing page Vanta network background so the animation spins more slowly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe54662be4832b8d3c0ec31679d1f0