### PR TITLE
Implement static multi-idiom Normal Rooms site

### DIFF
--- a/P01_MVP_Build_Brief.md
+++ b/P01_MVP_Build_Brief.md
@@ -1,7 +1,7 @@
 # P01 MVP Build Brief: Docusaurus Static Knowledge Site
 
 ## 1. Purpose
-Deliver a static, GitHub Pages–friendly Docusaurus site that unifies three content idioms—Wiki (reference), Blog (chronological updates), and Lab Notebook (structured experiment entries)—plus lightweight project hubs. The site must be simple, deterministic to build, and extensible without rewriting content. All artifacts are generated at build time with no runtime fetching.
+Deliver a static, GitHub Pages–friendly Docusaurus site that unifies three content idioms—Wiki (reference), Blog (chronological updates), and Lab Notebook (structured experiment entries)—plus lightweight project hubs. The site must be simple, deterministic to build, and extensible without rewriting content. All artifacts are generated at build time with no runtime fetching. The visual tone embraces a minimal, modern gray-and-orange palette with restrained typography.
 
 ## 2. Non-Negotiable Constraints
 1. **Static generation only** – Every page, index, and search artifact is produced during `docusaurus build`. Client-side behavior operates solely on prebuilt data.
@@ -12,7 +12,7 @@ Deliver a static, GitHub Pages–friendly Docusaurus site that unifies three con
 6. **Stable, human-readable links** – Adopt predictable slugs. Integrate the official link checker (`docusaurus-lint-links`) into CI before publish.
 
 ## 3. Information Architecture & Routing
-- **Top-level routes**: `/` (landing), `/docs` (wiki + projects), `/blog` (updates), `/lab` (lab notebook), `/tags` (aggregate tag pages), `/search` (client-side search UI), `/contact`, `/donate`, `/legal`.
+- **Top-level routes**: `/` (landing with ENTER gate), `/home` (interior landing), `/docs` (wiki + projects), `/blog` (updates), `/lab` (lab notebook), `/tags` (aggregate tag pages), `/search` (client-side search UI), `/contact`, `/donate`, `/legal`.
 - **Wiki & projects**: Organized under `/docs`, with sidebars grouping evergreen topics and project hubs.
 - **Blog**: Uses built-in blog plugin for chronological posts with archives and tag filtering.
 - **Lab notebook**: Custom docs plugin instance (e.g., second docs plugin) at `/lab` with its own sidebar hierarchy.
@@ -62,7 +62,8 @@ root/
 │  │  └─ ProjectRelatedList.tsx (shared list component)
 │  ├─ css/ (light theme overrides)
 │  └─ pages/
-│     ├─ index.tsx (landing page)
+│     ├─ index.tsx (landing gate with ENTER interaction)
+│     ├─ home.tsx (interior landing page)
 │     ├─ search.tsx (search interface wired to static index)
 │     ├─ contact.md
 │     ├─ donate.md
@@ -75,11 +76,12 @@ root/
 
 ## 6. Feature Breakdown
 
-### 6.1 Landing Page (`/`)
-- Present one-sentence purpose.
-- Highlight three CTA cards: Wiki, Blog, Lab. Each links to respective index.
-- Optional “Recent” list (3 items max) populated from statically generated JSON built during build.
-- Light hero styling via theme custom CSS; ensure readable without JS.
+### 6.1 Landing Page (`/` + `/home`)
+- `/` presents a sparse, centered layout in gray and orange with a single "ENTER" call-to-action (button or link) and the one-sentence purpose beneath it. Minimal animation (e.g., hover color shift) only.
+- The ENTER interaction navigates to `/home`, which contains the interior landing content and is directly addressable.
+- `/home` repeats the purpose statement, highlights three CTA cards (Wiki, Blog, Lab) with short descriptions, and links to respective indexes.
+- An optional “Recent” list (max three items) may appear on `/home` if populated from statically generated JSON produced during the build; otherwise link to full lists.
+- Ensure both `/` and `/home` remain fully readable without JavaScript and respect the gray/orange palette via lightweight CSS overrides.
 
 ### 6.2 Wiki (`/docs`)
 - Use Docusaurus classic preset docs plugin.
@@ -113,7 +115,7 @@ root/
 - Configure tag routes to display aggregated items across idioms using prebuilt metadata (e.g., `generated/tag-maps.json`).
 
 ### 6.8 Navigation Chrome
-- Header: persistent links to Wiki, Blog, Lab, Search.
+- Header: persistent links to Home, Wiki, Blog, Lab, Search.
 - Footer: sections for About, Contact, Support, Legal. All pages static.
 - Use theme `NavbarItem` configuration; keep styling minimal.
 

--- a/about.html
+++ b/about.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · About</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="wiki.html">Wiki</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="lab.html">Lab Notebook</a></li>
+          <li><a href="projects.html">Projects</a></li>
+          <li><a href="tags.html">Tags</a></li>
+          <li><a href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="page">
+    <div class="container">
+      <header class="page-header">
+        <p class="eyebrow">About</p>
+        <h1>Normal Rooms</h1>
+        <p>A minimal knowledge hub spanning documentation, updates, and lab notes.</p>
+      </header>
+      <div class="page__content">
+        <p>
+          Normal Rooms exists to keep product, research, and operations aligned through a single
+          static site. Every page is generated ahead of time and deployed to GitHub Pages for
+          durability.
+        </p>
+        <p>
+          The project leans on the Docusaurus mental model—docs, blog, custom pages—to ensure future
+          expansion remains straightforward. Contributors author Markdown/MDX files once and let the
+          build surface the right format for each idiom.
+        </p>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a aria-current="page" href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="donate.html">Support</a></li>
+          <li><a href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · Blog</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="wiki.html">Wiki</a></li>
+          <li><a aria-current="page" href="blog.html">Blog</a></li>
+          <li><a href="lab.html">Lab Notebook</a></li>
+          <li><a href="projects.html">Projects</a></li>
+          <li><a href="tags.html">Tags</a></li>
+          <li><a href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="blog">
+    <div class="container">
+      <header class="page-header">
+        <p class="eyebrow">Updates</p>
+        <h1>Blog</h1>
+        <p>Reverse-chronological updates tracking Normal Rooms milestones.</p>
+      </header>
+
+      <section class="blog__list" aria-label="Blog posts">
+        <article class="post-card" id="may-2024">
+          <header>
+            <h2><a href="blog/aligning-static-workflows.html">Aligning static workflows with research cadence</a></h2>
+            <p class="post-card__meta">May 24, 2024 · Update · Tags: <a class="tag" href="tags.html#workflow">workflow</a>, <a class="tag" href="tags.html#lab">lab</a></p>
+          </header>
+          <p>
+            We consolidated the static publishing workflow with the lab notebook schedule, ensuring
+            experiment learnings propagate to the wiki and project hubs without duplicated content.
+          </p>
+          <a class="card__link" href="blog/aligning-static-workflows.html">Read more</a>
+        </article>
+
+        <article class="post-card">
+          <header>
+            <h2><a href="blog/lab-index-release.html">Publishing the first unified lab index</a></h2>
+            <p class="post-card__meta">May 10, 2024 · Release · Tags: <a class="tag" href="tags.html#lab">lab</a>, <a class="tag" href="tags.html#quality">quality</a></p>
+          </header>
+          <p>
+            The first iteration of our lab notebook index ships with static search data and project
+            cross-links, making it easy to trace experiments by aim or related feature work.
+          </p>
+          <a class="card__link" href="blog/lab-index-release.html">Read more</a>
+        </article>
+
+        <article class="post-card" id="april-2024">
+          <header>
+            <h2><a href="blog/welcome.html">Welcome to Normal Rooms</a></h2>
+            <p class="post-card__meta">April 18, 2024 · Announcement · Tags: <a class="tag" href="tags.html#announcement">announcement</a></p>
+          </header>
+          <p>
+            We introduced the Normal Rooms knowledge hub, outlining the core idioms—wiki, blog, lab
+            notebook, and project hubs—that keep our work discoverable and durable.
+          </p>
+          <a class="card__link" href="blog/welcome.html">Read more</a>
+        </article>
+      </section>
+
+      <section class="archives">
+        <h2>Archives</h2>
+        <ul class="list">
+          <li><a href="blog.html#may-2024">May 2024</a></li>
+          <li><a href="blog.html#april-2024">April 2024</a></li>
+        </ul>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="donate.html">Support</a></li>
+          <li><a href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/blog/aligning-static-workflows.html
+++ b/blog/aligning-static-workflows.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Aligning static workflows with research cadence · Normal Rooms</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="../home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="../wiki.html">Wiki</a></li>
+          <li><a aria-current="page" href="../blog.html">Blog</a></li>
+          <li><a href="../lab.html">Lab Notebook</a></li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li><a href="../tags.html">Tags</a></li>
+          <li><a href="../search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="post">
+    <article class="container">
+      <header class="post__header">
+        <p class="post__meta">May 24, 2024 · Update</p>
+        <h1>Aligning static workflows with research cadence</h1>
+        <p class="post__tags">
+          Tags: <a class="tag" href="../tags.html#workflow">workflow</a>,
+          <a class="tag" href="../tags.html#lab">lab</a>
+        </p>
+      </header>
+      <div class="post__content">
+        <p>
+          Our latest build closed the gap between experiment logging and public documentation. Lab
+          entries now trigger wiki cross-links during the static build, and the project hubs track the
+          same metadata.
+        </p>
+        <p>
+          We automated link validation across wiki anchors, project hubs, and lab entry IDs, keeping
+          everything consistent without manual sweeps.
+        </p>
+      </div>
+      <footer class="post__footer">
+        <p>Related lab entry: <a href="../lab/search-prototype-benchmark.html">NR-LAB-005</a></p>
+      </footer>
+    </article>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="../about.html">About</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+          <li><a href="../donate.html">Support</a></li>
+          <li><a href="../legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/blog/lab-index-release.html
+++ b/blog/lab-index-release.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Publishing the first unified lab index · Normal Rooms</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="../home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="../wiki.html">Wiki</a></li>
+          <li><a aria-current="page" href="../blog.html">Blog</a></li>
+          <li><a href="../lab.html">Lab Notebook</a></li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li><a href="../tags.html">Tags</a></li>
+          <li><a href="../search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="post">
+    <article class="container">
+      <header class="post__header">
+        <p class="post__meta">May 10, 2024 · Release</p>
+        <h1>Publishing the first unified lab index</h1>
+        <p class="post__tags">
+          Tags: <a class="tag" href="../tags.html#lab">lab</a>,
+          <a class="tag" href="../tags.html#quality">quality</a>
+        </p>
+      </header>
+      <div class="post__content">
+        <p>
+          The lab notebook now ships with a structured index generated during builds. Each entry
+          includes aim, method, observations, result, and next actions.
+        </p>
+        <p>
+          By pairing the JSON search index with explicit metadata, we’ve made it easier to surface
+          experiments across project hubs and tag pages.
+        </p>
+      </div>
+      <footer class="post__footer">
+        <p>Related project: <a href="../projects.html#project-static-pipeline">Static pipeline hardening</a></p>
+      </footer>
+    </article>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="../about.html">About</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+          <li><a href="../donate.html">Support</a></li>
+          <li><a href="../legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/blog/welcome.html
+++ b/blog/welcome.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Welcome to Normal Rooms · Normal Rooms</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="../home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="../wiki.html">Wiki</a></li>
+          <li><a aria-current="page" href="../blog.html">Blog</a></li>
+          <li><a href="../lab.html">Lab Notebook</a></li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li><a href="../tags.html">Tags</a></li>
+          <li><a href="../search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="post">
+    <article class="container">
+      <header class="post__header">
+        <p class="post__meta">April 18, 2024 · Announcement</p>
+        <h1>Welcome to Normal Rooms</h1>
+        <p class="post__tags">
+          Tags: <a class="tag" href="../tags.html#announcement">announcement</a>
+        </p>
+      </header>
+      <div class="post__content">
+        <p>
+          Welcome to the Normal Rooms knowledge hub. This site brings together documentation,
+          updates, and experiment logs in a minimal, static package.
+        </p>
+        <p>
+          The landing page introduces a calm gray and orange gate; the interior route offers the wiki,
+          blog, lab notebook, project hubs, and a static search index.
+        </p>
+      </div>
+      <footer class="post__footer">
+        <p>Next read: <a href="../wiki.html#foundations">Foundations</a></p>
+      </footer>
+    </article>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="../about.html">About</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+          <li><a href="../donate.html">Support</a></li>
+          <li><a href="../legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · Contact</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="wiki.html">Wiki</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="lab.html">Lab Notebook</a></li>
+          <li><a href="projects.html">Projects</a></li>
+          <li><a href="tags.html">Tags</a></li>
+          <li><a href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="page">
+    <div class="container">
+      <header class="page-header">
+        <p class="eyebrow">Contact</p>
+        <h1>Reach the Normal Rooms team</h1>
+        <p>Drop a line for collaboration, questions, or feedback.</p>
+      </header>
+      <div class="page__content">
+        <p>
+          For general inquiries, email <a href="mailto:hello@normalrooms.example">hello@normalrooms.example</a>.
+        </p>
+        <p>
+          We respond to most requests within two business days. For urgent matters, include “URGENT”
+          in the subject line so the static triage process routes your note appropriately.
+        </p>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="about.html">About</a></li>
+          <li><a aria-current="page" href="contact.html">Contact</a></li>
+          <li><a href="donate.html">Support</a></li>
+          <li><a href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/data/search-index.json
+++ b/data/search-index.json
@@ -1,0 +1,80 @@
+[
+  {
+    "title": "Foundations",
+    "description": "Core principles behind the Normal Rooms static site.",
+    "url": "wiki.html#foundations",
+    "tags": ["wiki", "architecture", "workflow"]
+  },
+  {
+    "title": "Architecture",
+    "description": "How the Docusaurus-inspired structure keeps content consistent.",
+    "url": "wiki.html#architecture",
+    "tags": ["wiki", "static", "projects"]
+  },
+  {
+    "title": "Publishing workflow",
+    "description": "Single-source Markdown pipeline with static search indexing.",
+    "url": "wiki.html#publishing",
+    "tags": ["wiki", "build", "quality"]
+  },
+  {
+    "title": "Governance",
+    "description": "Tag management and process alignment for Normal Rooms.",
+    "url": "wiki.html#governance",
+    "tags": ["wiki", "governance", "process"]
+  },
+  {
+    "title": "Aligning static workflows with research cadence",
+    "description": "Synchronizing lab entries with wiki and project updates.",
+    "url": "blog/aligning-static-workflows.html",
+    "tags": ["blog", "workflow", "lab"]
+  },
+  {
+    "title": "Publishing the first unified lab index",
+    "description": "Launching the lab notebook index and static search payload.",
+    "url": "blog/lab-index-release.html",
+    "tags": ["blog", "lab", "quality"]
+  },
+  {
+    "title": "Welcome to Normal Rooms",
+    "description": "Introducing the knowledge hub and gated landing page.",
+    "url": "blog/welcome.html",
+    "tags": ["blog", "announcement"]
+  },
+  {
+    "title": "NR-LAB-006 · Delta observation window stress test",
+    "description": "Stress testing the delta visualization during rapid rebuilds.",
+    "url": "lab/delta-observation-window.html",
+    "tags": ["lab", "performance"]
+  },
+  {
+    "title": "NR-LAB-005 · Client-side search prototype benchmark",
+    "description": "Benchmarking latency for the static search index.",
+    "url": "lab/search-prototype-benchmark.html",
+    "tags": ["lab", "search", "quality"]
+  },
+  {
+    "title": "NR-LAB-004 · Landing gate usability scan",
+    "description": "Testing the clarity and tone of the new landing gate.",
+    "url": "lab/landing-gate-usability.html",
+    "tags": ["lab", "ux", "workflow"]
+  },
+  {
+    "title": "Static pipeline hardening",
+    "description": "Project hub connecting build improvements across idioms.",
+    "url": "projects.html#project-static-pipeline",
+    "tags": ["project", "build", "quality"]
+  },
+  {
+    "title": "Knowledge graph curation",
+    "description": "Taxonomy stewardship for tags, projects, and experiments.",
+    "url": "projects.html#project-knowledge-graph",
+    "tags": ["project", "governance", "workflow"]
+  },
+  {
+    "title": "Landing experience refresh",
+    "description": "Maintaining the gray-and-orange gate experience.",
+    "url": "projects.html#project-landing-experience",
+    "tags": ["project", "ux", "announcement"]
+  }
+]

--- a/donate.html
+++ b/donate.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · Support</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="wiki.html">Wiki</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="lab.html">Lab Notebook</a></li>
+          <li><a href="projects.html">Projects</a></li>
+          <li><a href="tags.html">Tags</a></li>
+          <li><a href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="page">
+    <div class="container">
+      <header class="page-header">
+        <p class="eyebrow">Support</p>
+        <h1>Help sustain Normal Rooms</h1>
+        <p>Your support keeps the static infrastructure maintained and accessible to everyone.</p>
+      </header>
+      <div class="page__content">
+        <p>
+          Normal Rooms is free to read and host. If you’d like to support ongoing research synthesis,
+          consider one of the options below:
+        </p>
+        <ul>
+          <li><a href="https://opencollective.com" target="_blank" rel="noopener">Open Collective</a> for recurring contributions.</li>
+          <li><a href="https://buymeacoffee.com" target="_blank" rel="noopener">Buy Me a Coffee</a> for one-off boosts.</li>
+        </ul>
+        <p>
+          We keep supporters updated through the blog and project hubs—no additional mailing lists or
+          tracking pixels.
+        </p>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a aria-current="page" href="donate.html">Support</a></li>
+          <li><a href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/home.html
+++ b/home.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · Home</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="wiki.html">Wiki</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="lab.html">Lab Notebook</a></li>
+          <li><a href="projects.html">Projects</a></li>
+          <li><a href="tags.html">Tags</a></li>
+          <li><a href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero__inner">
+        <div class="hero__copy">
+          <p class="eyebrow">Static, calm, durable</p>
+          <h1>One source of truth for Normal Rooms.</h1>
+          <p>
+            Every artifact on this site is generated ahead of time. Browse evergreen reference
+            material, catch up on chronological updates, or audit experiment notes—all from the same
+            Markdown-first substrate.
+          </p>
+          <div class="hero__actions">
+            <a class="button" href="wiki.html">Explore the Wiki</a>
+            <a class="button button--ghost" href="blog.html">Read the Blog</a>
+          </div>
+        </div>
+        <div class="hero__panel" aria-hidden="true">
+          <ul class="hero__stats">
+            <li>
+              <span class="hero__stat-label">Evergreen Articles</span>
+              <span class="hero__stat-value">12</span>
+            </li>
+            <li>
+              <span class="hero__stat-label">Project Hubs</span>
+              <span class="hero__stat-value">3</span>
+            </li>
+            <li>
+              <span class="hero__stat-label">Lab Experiments</span>
+              <span class="hero__stat-value">6</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--alt">
+      <div class="container section__inner">
+        <header class="section-header">
+          <p class="eyebrow">Multi-idiom publishing</p>
+          <h2>Three ways to engage with the work.</h2>
+          <p>
+            Content is authored once and surfaced where it matters. Tags and cross-links keep the
+            wiki, blog, and lab notebook synchronized without duplication.
+          </p>
+        </header>
+        <div class="grid grid--three">
+          <article class="card">
+            <h3>Wiki</h3>
+            <p>Evergreen reference pages with contextual navigation and deep linking.</p>
+            <a class="card__link" href="wiki.html">Browse articles</a>
+          </article>
+          <article class="card">
+            <h3>Blog</h3>
+            <p>Chronological updates with archives and tags for historical context.</p>
+            <a class="card__link" href="blog.html">Read updates</a>
+          </article>
+          <article class="card">
+            <h3>Lab notebook</h3>
+            <p>Structured experiment entries that capture aim, method, and follow-up.</p>
+            <a class="card__link" href="lab.html">Review experiments</a>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container section__inner">
+        <header class="section-header">
+          <p class="eyebrow">Stay oriented</p>
+          <h2>Recent highlights</h2>
+        </header>
+        <div class="grid grid--two">
+          <article class="card card--list">
+            <h3>Latest blog posts</h3>
+            <ul class="list">
+              <li>
+                <span class="list__meta">May 24, 2024 · Update</span>
+                <a href="blog/aligning-static-workflows.html">Aligning static workflows with research cadence</a>
+              </li>
+              <li>
+                <span class="list__meta">May 10, 2024 · Release</span>
+                <a href="blog/lab-index-release.html">Publishing the first unified lab index</a>
+              </li>
+            </ul>
+            <a class="card__link" href="blog.html">View all posts</a>
+          </article>
+          <article class="card card--list">
+            <h3>Latest lab entries</h3>
+            <ul class="list">
+              <li>
+                <span class="list__meta">Experiment · NR-LAB-006</span>
+                <a href="lab/delta-observation-window.html">Delta observation window stress test</a>
+              </li>
+              <li>
+                <span class="list__meta">Experiment · NR-LAB-005</span>
+                <a href="lab/search-prototype-benchmark.html">Client-side search prototype benchmark</a>
+              </li>
+            </ul>
+            <a class="card__link" href="lab.html">View all experiments</a>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="donate.html">Support</a></li>
+          <li><a href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,96 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Normal Rooms</title>
-  <style>
-    html, body {
-      margin: 0;
-      height: 100%;
-      overflow: hidden;
-      background-color: #44414a;
-      font-family: 'Helvetica Neue', sans-serif;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    #vanta-bg {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      z-index: 0;
-    }
-
-    h1 {
-      position: relative;
-      color: #ff773f;
-      font-size: 4rem;
-      font-weight: 700;
-      letter-spacing: 0.1em;
-      z-index: 1;
-      text-transform: uppercase;
-    }
-  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
-  <div id="vanta-bg"></div>
-  <h1>NORMAL ROOMS</h1>
-
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vanta/dist/vanta.net.min.js"></script>
-  <script>
-    let vantaEffect = VANTA.NET({
-      el: "#vanta-bg",
-      mouseControls: true,
-      touchControls: true,
-      gyroControls: false,
-      minHeight: 200.00,
-      minWidth: 200.00,
-      scale: 1.00,
-      scaleMobile: 1.00,
-      color: 0xff773f,
-      backgroundColor: 0x44414a,
-      points: 15.00,
-      spacing: 18.00,
-      maxDistance: 18.00,
-      showDots: true
-    });
-
-    // Super-fast continuous rotation around two axes
-    let angleX = 0;
-    let angleY = 0;
-    let rotationSpeedX = 0.005; // X-axis speed
-    let rotationSpeedY = 0.004; // Y-axis speed
-
-    // Function to modulate network geometry dynamically
-    function modulateNetwork() {
-      if (vantaEffect && vantaEffect.particles) {
-        const time = Date.now() * 0.001;
-        vantaEffect.particles.forEach((p, i) => {
-          const offset = i * 0.3;
-          p.position.x += Math.sin(time + offset) * 0.05;
-          p.position.y += Math.cos(time * 1.2 + offset) * 0.05;
-        });
-      }
-    }
-
-    // Continuous animation loop
-    function animate() {
-      requestAnimationFrame(animate);
-      if (vantaEffect && vantaEffect.scene) {
-        modulateNetwork();
-        vantaEffect.scene.rotation.x = angleX;
-        vantaEffect.scene.rotation.y = angleY;
-        angleX += rotationSpeedX;
-        angleY += rotationSpeedY;
-      }
-    }
-
-    animate();
-  </script>
+<body class="landing">
+  <main class="landing__wrap" aria-labelledby="site-title">
+    <div class="landing__frame">
+      <span class="landing__tag">Normal Rooms</span>
+      <h1 id="site-title">Documentation, updates, and lab notes in one calm space.</h1>
+      <p class="landing__copy">
+        A minimal, static hub for the Normal Rooms project. Explore the wiki, read the latest
+        updates, and review structured experiment logs—everything generated ahead of time and
+        ready for GitHub Pages.
+      </p>
+      <a class="button landing__cta" href="home.html">Enter</a>
+    </div>
+  </main>
 </body>
 </html>

--- a/lab.html
+++ b/lab.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · Lab Notebook</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="wiki.html">Wiki</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a aria-current="page" href="lab.html">Lab Notebook</a></li>
+          <li><a href="projects.html">Projects</a></li>
+          <li><a href="tags.html">Tags</a></li>
+          <li><a href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="lab">
+    <div class="container">
+      <header class="page-header">
+        <p class="eyebrow">Experiments</p>
+        <h1>Lab Notebook</h1>
+        <p>Structured, append-only experiment entries that surface across the wiki and blog.</p>
+      </header>
+
+      <section class="lab__entries" aria-label="Lab entries">
+        <article class="lab-entry">
+          <header class="lab-entry__header">
+            <div>
+              <h2><a href="lab/delta-observation-window.html">NR-LAB-006 · Delta observation window stress test</a></h2>
+              <p class="lab-entry__meta">Status: Completed · Tags: <a class="tag" href="tags.html#lab">lab</a>, <a class="tag" href="tags.html#performance">performance</a></p>
+            </div>
+            <span class="lab-entry__date">Logged May 22, 2024</span>
+          </header>
+          <dl class="lab-entry__details">
+            <div>
+              <dt>Aim</dt>
+              <dd>Validate that the static delta visualization remains legible during rapid content updates.</dd>
+            </div>
+            <div>
+              <dt>Method</dt>
+              <dd>Generated synthetic commits in the docs folder and rebuilt the site to monitor visual stability.</dd>
+            </div>
+            <div>
+              <dt>Observations</dt>
+              <dd>Search index rebuilds remained under four seconds; nav anchors preserved focus states.</dd>
+            </div>
+            <div>
+              <dt>Result</dt>
+              <dd>The delta visualization held; no regressions detected.</dd>
+            </div>
+            <div>
+              <dt>Next</dt>
+              <dd>Document the rebuild guardrails in the wiki and reference them from the project hub.</dd>
+            </div>
+          </dl>
+        </article>
+
+        <article class="lab-entry">
+          <header class="lab-entry__header">
+            <div>
+              <h2><a href="lab/search-prototype-benchmark.html">NR-LAB-005 · Client-side search prototype benchmark</a></h2>
+              <p class="lab-entry__meta">Status: Completed · Tags: <a class="tag" href="tags.html#search">search</a>, <a class="tag" href="tags.html#quality">quality</a></p>
+            </div>
+            <span class="lab-entry__date">Logged May 8, 2024</span>
+          </header>
+          <dl class="lab-entry__details">
+            <div>
+              <dt>Aim</dt>
+              <dd>Measure the responsiveness of the static JSON search index under varied dataset sizes.</dd>
+            </div>
+            <div>
+              <dt>Method</dt>
+              <dd>Executed local Lighthouse runs against 10k synthetic entries while profiling input latency.</dd>
+            </div>
+            <div>
+              <dt>Observations</dt>
+              <dd>Input responsiveness stayed under 60ms; JSON payload remained under 500kb compressed.</dd>
+            </div>
+            <div>
+              <dt>Result</dt>
+              <dd>Prototype passes the performance budget and is cleared for inclusion in production builds.</dd>
+            </div>
+            <div>
+              <dt>Next</dt>
+              <dd>Document integration steps for the build pipeline and add regression checks.</dd>
+            </div>
+          </dl>
+        </article>
+
+        <article class="lab-entry">
+          <header class="lab-entry__header">
+            <div>
+              <h2><a href="lab/landing-gate-usability.html">NR-LAB-004 · Landing gate usability scan</a></h2>
+              <p class="lab-entry__meta">Status: Completed · Tags: <a class="tag" href="tags.html#ux">ux</a>, <a class="tag" href="tags.html#workflow">workflow</a></p>
+            </div>
+            <span class="lab-entry__date">Logged April 29, 2024</span>
+          </header>
+          <dl class="lab-entry__details">
+            <div>
+              <dt>Aim</dt>
+              <dd>Confirm the landing gate improves clarity without blocking known contributors.</dd>
+            </div>
+            <div>
+              <dt>Method</dt>
+              <dd>Ran remote tests with five participants comparing direct vs gated entry to the site.</dd>
+            </div>
+            <div>
+              <dt>Observations</dt>
+              <dd>Participants appreciated the calm aesthetic; no confusion about the ENTER action.</dd>
+            </div>
+            <div>
+              <dt>Result</dt>
+              <dd>Gate retained; copy updated to highlight the site’s three idioms.</dd>
+            </div>
+            <div>
+              <dt>Next</dt>
+              <dd>Roll the copy updates into the landing page and document the decision in the wiki.</dd>
+            </div>
+          </dl>
+        </article>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="donate.html">Support</a></li>
+          <li><a href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/lab/delta-observation-window.html
+++ b/lab/delta-observation-window.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>NR-LAB-006 · Delta observation window stress test · Normal Rooms</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="../home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="../wiki.html">Wiki</a></li>
+          <li><a href="../blog.html">Blog</a></li>
+          <li><a aria-current="page" href="../lab.html">Lab Notebook</a></li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li><a href="../tags.html">Tags</a></li>
+          <li><a href="../search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="page">
+    <article class="container">
+      <header class="lab-detail__header">
+        <p class="lab-detail__meta">NR-LAB-006 · Logged May 22, 2024 · Completed</p>
+        <h1>Delta observation window stress test</h1>
+        <p class="post__tags">
+          Tags: <a class="tag" href="../tags.html#lab">lab</a>, <a class="tag" href="../tags.html#performance">performance</a>
+        </p>
+      </header>
+      <dl class="lab-entry__details">
+        <div>
+          <dt>Aim</dt>
+          <dd>Validate that the static delta visualization remains legible during rapid content updates.</dd>
+        </div>
+        <div>
+          <dt>Method</dt>
+          <dd>Generated synthetic commits in the docs folder and rebuilt the site to monitor visual stability.</dd>
+        </div>
+        <div>
+          <dt>Observations</dt>
+          <dd>Search index rebuilds remained under four seconds; nav anchors preserved focus states.</dd>
+        </div>
+        <div>
+          <dt>Result</dt>
+          <dd>The delta visualization held; no regressions detected.</dd>
+        </div>
+        <div>
+          <dt>Next</dt>
+          <dd>Document the rebuild guardrails in the wiki and reference them from the project hub.</dd>
+        </div>
+      </dl>
+      <footer class="lab-detail__footer">
+        <p>Related project: <a href="../projects.html#project-static-pipeline">Static pipeline hardening</a></p>
+      </footer>
+    </article>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="../about.html">About</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+          <li><a href="../donate.html">Support</a></li>
+          <li><a href="../legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/lab/landing-gate-usability.html
+++ b/lab/landing-gate-usability.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>NR-LAB-004 · Landing gate usability scan · Normal Rooms</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="../home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="../wiki.html">Wiki</a></li>
+          <li><a href="../blog.html">Blog</a></li>
+          <li><a aria-current="page" href="../lab.html">Lab Notebook</a></li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li><a href="../tags.html">Tags</a></li>
+          <li><a href="../search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="page">
+    <article class="container">
+      <header class="lab-detail__header">
+        <p class="lab-detail__meta">NR-LAB-004 · Logged April 29, 2024 · Completed</p>
+        <h1>Landing gate usability scan</h1>
+        <p class="post__tags">
+          Tags: <a class="tag" href="../tags.html#ux">ux</a>, <a class="tag" href="../tags.html#workflow">workflow</a>
+        </p>
+      </header>
+      <dl class="lab-entry__details">
+        <div>
+          <dt>Aim</dt>
+          <dd>Confirm the landing gate improves clarity without blocking known contributors.</dd>
+        </div>
+        <div>
+          <dt>Method</dt>
+          <dd>Ran remote tests with five participants comparing direct vs gated entry to the site.</dd>
+        </div>
+        <div>
+          <dt>Observations</dt>
+          <dd>Participants appreciated the calm aesthetic; no confusion about the ENTER action.</dd>
+        </div>
+        <div>
+          <dt>Result</dt>
+          <dd>Gate retained; copy updated to highlight the site’s three idioms.</dd>
+        </div>
+        <div>
+          <dt>Next</dt>
+          <dd>Roll the copy updates into the landing page and document the decision in the wiki.</dd>
+        </div>
+      </dl>
+      <footer class="lab-detail__footer">
+        <p>Referenced in: <a href="../blog/welcome.html">Welcome to Normal Rooms</a></p>
+      </footer>
+    </article>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="../about.html">About</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+          <li><a href="../donate.html">Support</a></li>
+          <li><a href="../legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/lab/search-prototype-benchmark.html
+++ b/lab/search-prototype-benchmark.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>NR-LAB-005 · Client-side search prototype benchmark · Normal Rooms</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="../home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="../wiki.html">Wiki</a></li>
+          <li><a href="../blog.html">Blog</a></li>
+          <li><a aria-current="page" href="../lab.html">Lab Notebook</a></li>
+          <li><a href="../projects.html">Projects</a></li>
+          <li><a href="../tags.html">Tags</a></li>
+          <li><a href="../search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="page">
+    <article class="container">
+      <header class="lab-detail__header">
+        <p class="lab-detail__meta">NR-LAB-005 · Logged May 8, 2024 · Completed</p>
+        <h1>Client-side search prototype benchmark</h1>
+        <p class="post__tags">
+          Tags: <a class="tag" href="../tags.html#search">search</a>, <a class="tag" href="../tags.html#quality">quality</a>
+        </p>
+      </header>
+      <dl class="lab-entry__details">
+        <div>
+          <dt>Aim</dt>
+          <dd>Measure the responsiveness of the static JSON search index under varied dataset sizes.</dd>
+        </div>
+        <div>
+          <dt>Method</dt>
+          <dd>Executed local Lighthouse runs against 10k synthetic entries while profiling input latency.</dd>
+        </div>
+        <div>
+          <dt>Observations</dt>
+          <dd>Input responsiveness stayed under 60ms; JSON payload remained under 500kb compressed.</dd>
+        </div>
+        <div>
+          <dt>Result</dt>
+          <dd>Prototype passes the performance budget and is cleared for inclusion in production builds.</dd>
+        </div>
+        <div>
+          <dt>Next</dt>
+          <dd>Document integration steps for the build pipeline and add regression checks.</dd>
+        </div>
+      </dl>
+      <footer class="lab-detail__footer">
+        <p>Referenced in: <a href="../blog/aligning-static-workflows.html">Aligning static workflows</a></p>
+      </footer>
+    </article>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="../about.html">About</a></li>
+          <li><a href="../contact.html">Contact</a></li>
+          <li><a href="../donate.html">Support</a></li>
+          <li><a href="../legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/legal.html
+++ b/legal.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · Legal</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="wiki.html">Wiki</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="lab.html">Lab Notebook</a></li>
+          <li><a href="projects.html">Projects</a></li>
+          <li><a href="tags.html">Tags</a></li>
+          <li><a href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="page">
+    <div class="container">
+      <header class="page-header">
+        <p class="eyebrow">Legal</p>
+        <h1>Plain-language policies</h1>
+        <p>How we handle privacy, attribution, and licensing for Normal Rooms.</p>
+      </header>
+      <div class="page__content">
+        <section>
+          <h2>Privacy</h2>
+          <p>
+            We do not run tracking scripts or analytics. Server logs are managed by GitHub Pages and
+            used for aggregate uptime monitoring only. If you contact us, we use your email solely to
+            respond to your request.
+          </p>
+        </section>
+        <section>
+          <h2>Attribution</h2>
+          <p>
+            Unless noted otherwise, content is released under CC BY 4.0. Please attribute Normal Rooms
+            and link back to the relevant page when referencing material.
+          </p>
+        </section>
+        <section>
+          <h2>Licensing</h2>
+          <p>
+            Code samples and build tooling are provided under the MIT License. Third-party assets
+            maintain their original licenses and are noted inline when included.
+          </p>
+        </section>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="donate.html">Support</a></li>
+          <li><a aria-current="page" href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · Projects</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="wiki.html">Wiki</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="lab.html">Lab Notebook</a></li>
+          <li><a aria-current="page" href="projects.html">Projects</a></li>
+          <li><a href="tags.html">Tags</a></li>
+          <li><a href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="projects">
+    <div class="container">
+      <header class="page-header">
+        <p class="eyebrow">Hubs</p>
+        <h1>Projects</h1>
+        <p>Stable project hubs summarizing goals and linking to related work across the site.</p>
+      </header>
+
+      <section class="grid grid--three">
+        <article class="card card--project" id="project-static-pipeline">
+          <h2>Static pipeline hardening</h2>
+          <p>
+            Fortify the static build pipeline with reproducible checks, ensuring every deploy includes
+            search index updates and link validation.
+          </p>
+          <dl class="card__meta">
+            <div>
+              <dt>Related wiki</dt>
+              <dd><a href="wiki.html#publishing">Publishing workflow</a></dd>
+            </div>
+            <div>
+              <dt>Blog posts</dt>
+              <dd><a href="blog/aligning-static-workflows.html">Aligning static workflows</a></dd>
+            </div>
+            <div>
+              <dt>Lab entries</dt>
+              <dd><a href="lab/search-prototype-benchmark.html">NR-LAB-005</a></dd>
+            </div>
+            <div>
+              <dt>Tags</dt>
+              <dd><a class="tag" href="tags.html#build">build</a> <a class="tag" href="tags.html#quality">quality</a></dd>
+            </div>
+          </dl>
+        </article>
+
+        <article class="card card--project" id="project-knowledge-graph">
+          <h2>Knowledge graph curation</h2>
+          <p>
+            Establish a sustainable taxonomy for wiki topics, experiment IDs, and project identifiers
+            to keep cross-linking accurate.
+          </p>
+          <dl class="card__meta">
+            <div>
+              <dt>Related wiki</dt>
+              <dd><a href="wiki.html#governance">Governance</a></dd>
+            </div>
+            <div>
+              <dt>Blog posts</dt>
+              <dd><a href="blog/welcome.html">Welcome to Normal Rooms</a></dd>
+            </div>
+            <div>
+              <dt>Lab entries</dt>
+              <dd><a href="lab/landing-gate-usability.html">NR-LAB-004</a></dd>
+            </div>
+            <div>
+              <dt>Tags</dt>
+              <dd><a class="tag" href="tags.html#governance">governance</a> <a class="tag" href="tags.html#workflow">workflow</a></dd>
+            </div>
+          </dl>
+        </article>
+
+        <article class="card card--project" id="project-landing-experience">
+          <h2>Landing experience refresh</h2>
+          <p>
+            Maintain a calm gray-and-orange gate that sets the tone for the knowledge base while
+            keeping access frictionless.
+          </p>
+          <dl class="card__meta">
+            <div>
+              <dt>Related wiki</dt>
+              <dd><a href="wiki.html#foundations">Foundations</a></dd>
+            </div>
+            <div>
+              <dt>Blog posts</dt>
+              <dd><a href="blog/lab-index-release.html">Unified lab index release</a></dd>
+            </div>
+            <div>
+              <dt>Lab entries</dt>
+              <dd><a href="lab/landing-gate-usability.html">NR-LAB-004</a></dd>
+            </div>
+            <div>
+              <dt>Tags</dt>
+              <dd><a class="tag" href="tags.html#ux">ux</a> <a class="tag" href="tags.html#announcement">announcement</a></dd>
+            </div>
+          </dl>
+        </article>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="donate.html">Support</a></li>
+          <li><a href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -29,3 +29,76 @@ document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
     }
   });
 });
+
+function resolveAssetPath(asset) {
+  const script = document.querySelector('script[src*="script.js"]');
+  if (!script) return asset;
+  const src = script.getAttribute('src');
+  if (!src) return asset;
+  const base = src.replace(/script\.js.*/, '');
+  return `${base}${asset}`;
+}
+
+async function setupSearch() {
+  const searchInput = document.querySelector('#search-query');
+  const resultsContainer = document.querySelector('#search-results');
+
+  if (!searchInput || !resultsContainer) {
+    return;
+  }
+
+  let index = [];
+  try {
+    const response = await fetch(resolveAssetPath('data/search-index.json'));
+    if (!response.ok) throw new Error('Failed to load search index');
+    index = await response.json();
+  } catch (error) {
+    resultsContainer.innerHTML = '<p class="search__error">Unable to load the search index.</p>';
+    console.error(error);
+    return;
+  }
+
+  const renderResults = (query) => {
+    const normalized = query.trim().toLowerCase();
+
+    if (!normalized) {
+      resultsContainer.innerHTML = '<p class="search__empty">Start typing to see matching pages.</p>';
+      return;
+    }
+
+    const matches = index.filter((item) => {
+      const haystack = `${item.title} ${item.description} ${item.tags.join(' ')}`.toLowerCase();
+      return haystack.includes(normalized);
+    });
+
+    if (!matches.length) {
+      resultsContainer.innerHTML = `<p class="search__empty">No results for "${query}".</p>`;
+      return;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'search__list';
+
+    matches.forEach((item) => {
+      const entry = document.createElement('li');
+      entry.className = 'search__item';
+      entry.innerHTML = `
+        <a href="${item.url}">
+          <span class="search__item-title">${item.title}</span>
+          <span class="search__item-desc">${item.description}</span>
+          <span class="search__item-tags">${item.tags.map((tag) => `#${tag}`).join(' ')}</span>
+        </a>
+      `;
+      list.appendChild(entry);
+    });
+
+    resultsContainer.innerHTML = '';
+    resultsContainer.appendChild(list);
+  };
+
+  searchInput.addEventListener('input', (event) => {
+    renderResults(event.target.value);
+  });
+}
+
+setupSearch();

--- a/search.html
+++ b/search.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · Search</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="wiki.html">Wiki</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="lab.html">Lab Notebook</a></li>
+          <li><a href="projects.html">Projects</a></li>
+          <li><a href="tags.html">Tags</a></li>
+          <li><a aria-current="page" href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="search">
+    <div class="container">
+      <header class="page-header">
+        <p class="eyebrow">Static index</p>
+        <h1>Search</h1>
+        <p>Client-side search that queries a prebuilt JSON index generated at build time.</p>
+      </header>
+
+      <form class="search__form" role="search">
+        <label class="search__label" for="search-query">Search the wiki, blog, and lab notebook</label>
+        <input id="search-query" type="search" name="q" placeholder="Try 'search prototype'" autocomplete="off" />
+      </form>
+
+      <section class="search__results" id="search-results" aria-live="polite">
+        <p class="search__empty">Start typing to see matching pages.</p>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="donate.html">Support</a></li>
+          <li><a href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,17 @@
 :root {
-  --bg: #07081a;
-  --bg-alt: #0d0f2b;
-  --surface: rgba(255, 255, 255, 0.04);
+  --bg: #111216;
+  --bg-alt: #16171d;
+  --surface: rgba(255, 255, 255, 0.06);
   --surface-strong: rgba(255, 255, 255, 0.12);
   --surface-highlight: rgba(255, 255, 255, 0.18);
-  --text: #f4f6ff;
-  --text-muted: rgba(244, 246, 255, 0.7);
-  --accent: #6c5ce7;
-  --accent-soft: rgba(108, 92, 231, 0.2);
-  --accent-gradient: linear-gradient(135deg, #6c5ce7 0%, #4e9af1 50%, #00f5a0 100%);
-  --shadow-soft: 0 20px 45px rgba(7, 8, 26, 0.35);
-  --radius: 20px;
-  font-size: 16px;
+  --text: #f6f7f9;
+  --text-muted: rgba(246, 247, 249, 0.72);
+  --accent: #ff773f;
+  --accent-soft: rgba(255, 119, 63, 0.12);
+  --accent-strong: rgba(255, 119, 63, 0.28);
+  --shadow-soft: 0 18px 40px rgba(0, 0, 0, 0.25);
+  --radius: 18px;
+  --font: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 * {
@@ -22,16 +22,10 @@ html,
 body {
   margin: 0;
   padding: 0;
-  font-family: "Manrope", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: radial-gradient(circle at top left, rgba(108, 92, 231, 0.2), transparent 45%),
-    radial-gradient(circle at bottom right, rgba(0, 245, 160, 0.15), transparent 45%), var(--bg);
+  font-family: var(--font);
+  background: var(--bg);
   color: var(--text);
   line-height: 1.6;
-}
-
-img {
-  max-width: 100%;
-  display: block;
 }
 
 a {
@@ -41,109 +35,120 @@ a {
 
 a:hover,
 a:focus {
-  text-decoration: underline;
+  color: var(--accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
 }
 
 .container {
-  width: min(1100px, 90vw);
+  width: min(1100px, 92vw);
   margin: 0 auto;
 }
 
 .section {
-  padding: 6rem 0;
+  padding: 5rem 0;
 }
 
 .section--alt {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--bg-alt);
+}
+
+.section__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
 }
 
 .section-header {
   text-align: center;
-  margin-bottom: 3rem;
+  max-width: 640px;
+  margin: 0 auto;
 }
 
 .eyebrow {
   letter-spacing: 0.2em;
   text-transform: uppercase;
   font-weight: 600;
-  color: rgba(244, 246, 255, 0.65);
+  color: var(--text-muted);
   font-size: 0.8rem;
   margin-bottom: 1rem;
 }
 
 h1,
 h2,
-h3 {
+h3,
+h4 {
+  font-weight: 600;
   line-height: 1.2;
   margin: 0 0 1rem;
 }
 
 h1 {
-  font-size: clamp(2.5rem, 5vw, 3.5rem);
-  font-weight: 800;
+  font-size: clamp(2.5rem, 4.5vw, 3.25rem);
 }
 
 h2 {
   font-size: clamp(2rem, 4vw, 2.75rem);
-  font-weight: 700;
 }
 
 h3 {
-  font-size: 1.25rem;
-  font-weight: 600;
+  font-size: 1.6rem;
 }
 
 p {
-  margin: 0 0 1.25rem;
+  margin: 0 0 1.4rem;
   color: var(--text-muted);
 }
 
 ul {
-  padding: 0;
-  margin: 0;
   list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.85rem 1.75rem;
+  gap: 0.5rem;
+  padding: 0.9rem 1.8rem;
   border-radius: 999px;
-  font-weight: 600;
+  border: 1px solid transparent;
+  background: var(--accent);
   color: var(--bg);
-  background: var(--accent-gradient);
-  border: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   box-shadow: var(--shadow-soft);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .button:hover,
 .button:focus {
   transform: translateY(-2px);
-  box-shadow: 0 25px 50px rgba(16, 25, 64, 0.4);
+  background: #ffa676;
 }
 
 .button--ghost {
   background: transparent;
-  border: 1px solid rgba(244, 246, 255, 0.2);
+  border-color: var(--surface-highlight);
   color: var(--text);
   box-shadow: none;
 }
 
 .button--ghost:hover,
 .button--ghost:focus {
-  border-color: rgba(244, 246, 255, 0.4);
-  transform: translateY(-2px);
+  border-color: var(--accent);
 }
 
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 10;
-  backdrop-filter: blur(16px);
-  background: rgba(7, 8, 26, 0.8);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  z-index: 20;
+  backdrop-filter: blur(18px);
+  background: rgba(17, 18, 22, 0.82);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .header-inner {
@@ -163,469 +168,512 @@ ul {
 .brand-mark {
   display: grid;
   place-items: center;
-  width: 42px;
-  height: 42px;
+  width: 44px;
+  height: 44px;
   border-radius: 12px;
-  background: var(--accent-gradient);
+  background: var(--accent);
   color: var(--bg);
   font-weight: 800;
-}
-
-.site-nav {
-  display: flex;
-  align-items: center;
-  gap: 2rem;
+  letter-spacing: 0.08em;
 }
 
 .site-nav ul {
   display: flex;
-  align-items: center;
   gap: 1.5rem;
+  align-items: center;
   font-weight: 500;
+}
+
+.site-nav a[aria-current='page'] {
+  color: var(--accent);
 }
 
 .nav-toggle {
   display: none;
   background: none;
   border: none;
-  color: inherit;
   cursor: pointer;
+  color: var(--text);
 }
 
 .nav-toggle-bar {
   display: block;
-  width: 24px;
+  width: 26px;
   height: 2px;
-  background: var(--text);
+  background: currentColor;
   margin: 6px 0;
-  transition: transform 0.2s ease;
 }
 
 .hero {
-  padding: 8rem 0 6rem;
+  padding: 6rem 0 4rem;
 }
 
-.hero-inner {
+.hero__inner {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 3rem;
   align-items: center;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-.hero-copy p {
-  font-size: 1.05rem;
-}
-
-.hero-actions {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-  margin: 2rem 0 1.5rem;
-}
-
-.hero-trust p {
-  margin-bottom: 0.75rem;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: rgba(244, 246, 255, 0.5);
-}
-
-.hero-trust ul {
-  display: flex;
-  gap: 1.5rem;
-  flex-wrap: wrap;
-  font-weight: 600;
-  color: rgba(244, 246, 255, 0.65);
-}
-
-.hero-visual .dashboard {
-  background: rgba(12, 14, 38, 0.85);
-  border-radius: 32px;
-  padding: 2.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: var(--shadow-soft);
-  position: relative;
-  overflow: hidden;
-}
-
-.dashboard::after {
-  content: "";
-  position: absolute;
-  inset: -40% 40% 40% -40%;
-  background: var(--accent-gradient);
-  opacity: 0.15;
-  filter: blur(100px);
-}
-
-.dashboard-header,
-.dashboard-body,
-.dashboard-footer {
-  position: relative;
-  z-index: 1;
-}
-
-.dashboard-header {
-  display: flex;
-  gap: 1rem;
-  margin-bottom: 2rem;
-}
-
-.status {
-  padding: 0.5rem 1rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  background: rgba(244, 246, 255, 0.08);
-  color: rgba(244, 246, 255, 0.75);
-}
-
-.status--active {
-  background: var(--accent-gradient);
-  color: var(--bg);
-}
-
-.dashboard-body {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-}
-
-.stat-card {
-  padding: 1.5rem;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-}
-
-.stat-card h3 {
-  margin-bottom: 0.25rem;
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--text);
-}
-
-.trend {
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-
-.trend--up {
-  color: #4effc5;
-}
-
-.trend--down {
-  color: #ff8a8a;
-}
-
-.dashboard-footer {
-  margin-top: 2rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-  padding-top: 1.5rem;
-}
-
-.progress {
-  position: relative;
-  height: 6px;
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.progress span {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: var(--accent-gradient);
-}
-
-.feature-grid,
-.solution-grid,
-.testimonial-grid,
-.pricing-grid {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.feature-card,
-.solution-card,
-.pricing-card,
-.testimonial,
-.card,
-.metrics-card {
+.hero__panel {
   background: var(--surface);
+  border: 1px solid var(--surface-highlight);
   border-radius: var(--radius);
   padding: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.feature-card:hover,
-.solution-card:hover,
-.pricing-card:hover,
-.card:hover,
-.metrics-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(255, 255, 255, 0.15);
-  box-shadow: var(--shadow-soft);
-}
-
-.feature-icon {
-  font-size: 1.8rem;
-  display: inline-flex;
-  width: 48px;
-  height: 48px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 14px;
-  background: var(--accent-soft);
-  margin-bottom: 1.5rem;
-}
-
-.split {
-  display: grid;
-  gap: 3rem;
-  align-items: center;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.card-stack {
+.hero__stats {
   display: grid;
   gap: 1.5rem;
 }
 
-.card {
-  position: relative;
-}
-
-.card::before {
-  content: "";
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  padding: 1px;
-  background: var(--accent-gradient);
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask-composite: exclude;
-}
-
-.list {
-  display: grid;
-  gap: 0.75rem;
-  padding-left: 1.25rem;
+.hero__stat-label {
+  font-size: 0.9rem;
   color: var(--text-muted);
 }
 
-.list li {
-  position: relative;
+.hero__stat-value {
+  display: block;
+  font-size: 2.2rem;
+  font-weight: 700;
 }
 
-.list li::before {
-  content: "";
-  position: absolute;
-  left: -1.25rem;
-  top: 0.6rem;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent-gradient);
-}
-
-.list--compact {
-  gap: 0.5rem;
-}
-
-.testimonial blockquote {
-  margin: 0 0 1.5rem;
-  font-size: 1.05rem;
-  color: var(--text);
-}
-
-.metrics {
+.grid {
   display: grid;
   gap: 2rem;
-  align-items: center;
+}
+
+.grid--two {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.metrics-card {
+.grid--three {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--surface-highlight);
+  border-radius: var(--radius);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.card:hover,
+.card:focus-within {
+  border-color: var(--accent);
+  transform: translateY(-4px);
+}
+
+.card__link {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.card--list .list {
+  display: grid;
+  gap: 1rem;
+}
+
+.list__meta {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.tag-list {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding-top: 0.5rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.85rem;
+  border: 1px solid var(--accent-strong);
+}
+
+.site-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 2.5rem 0;
+  margin-top: 4rem;
+  background: rgba(17, 18, 22, 0.94);
+}
+
+.footer__inner {
+  display: grid;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.footer__links {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-weight: 500;
+}
+
+.footer__meta {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+/* Landing page */
+
+.landing {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top left, rgba(255, 119, 63, 0.18), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(255, 119, 63, 0.12), transparent 45%), var(--bg);
+}
+
+.landing__wrap {
+  width: min(620px, 90vw);
+}
+
+.landing__frame {
+  border: 1px solid var(--surface-highlight);
+  border-radius: calc(var(--radius) + 8px);
+  padding: 3rem;
+  background: var(--bg-alt);
+  box-shadow: var(--shadow-soft);
   text-align: center;
 }
 
-.metrics-card h3 {
-  font-size: 2.5rem;
-  margin-bottom: 0.5rem;
-  color: var(--text);
+.landing__tag {
+  display: inline-flex;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  margin-bottom: 1.5rem;
 }
 
-.pricing-grid {
-  align-items: stretch;
+.landing__copy {
+  margin-bottom: 2rem;
 }
 
-.pricing-card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
+/* Wiki */
+
+.wiki {
+  padding: 5rem 0;
 }
 
-.pricing-card .price {
-  font-size: 2.4rem;
-  font-weight: 700;
-  color: var(--text);
+.wiki__layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) 1fr;
+  gap: 3rem;
 }
 
-.pricing-card .price span {
+.wiki__sidebar {
+  position: sticky;
+  top: 120px;
+  align-self: start;
+  background: var(--surface);
+  border: 1px solid var(--surface-highlight);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+}
+
+.wiki__sidebar-title {
+  margin-top: 0;
+}
+
+.wiki__sidebar ul {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.wiki__content {
+  display: grid;
+  gap: 3rem;
+}
+
+.wiki__section {
+  background: var(--surface);
+  border: 1px solid var(--surface-highlight);
+  border-radius: var(--radius);
+  padding: 2rem;
+}
+
+.page-header {
+  margin-bottom: 2rem;
+}
+
+/* Blog */
+
+.blog {
+  padding: 4rem 0 5rem;
+}
+
+.blog__list {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.post-card {
+  background: var(--surface);
+  border: 1px solid var(--surface-highlight);
+  border-radius: var(--radius);
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.post-card__meta {
   font-size: 0.9rem;
-  font-weight: 500;
   color: var(--text-muted);
 }
 
-.pricing-card .button {
-  margin-top: auto;
+.archives {
+  margin-top: 4rem;
 }
 
-.pricing-card--highlight {
-  background: linear-gradient(145deg, rgba(108, 92, 231, 0.15), rgba(0, 245, 160, 0.12));
-  border: 1px solid rgba(108, 92, 231, 0.35);
-  box-shadow: var(--shadow-soft);
+/* Post detail */
+
+.post {
+  padding: 4rem 0 5rem;
 }
 
-.pricing-card .badge {
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
-  background: rgba(244, 246, 255, 0.12);
-  padding: 0.4rem 0.9rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+.post__header {
+  margin-bottom: 2rem;
 }
 
-.section--contact {
-  background: linear-gradient(160deg, rgba(108, 92, 231, 0.2), rgba(12, 14, 38, 0.9));
-  position: relative;
+.post__meta {
+  color: var(--text-muted);
+  font-size: 0.9rem;
 }
 
-.section--contact::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at top right, rgba(0, 245, 160, 0.25), transparent 45%);
-  opacity: 0.7;
-  pointer-events: none;
+.post__tags {
+  color: var(--text-muted);
 }
 
-.contact {
-  position: relative;
+.post__content {
+  background: var(--surface);
+  border: 1px solid var(--surface-highlight);
+  border-radius: var(--radius);
+  padding: 2rem;
+}
+
+.post__footer {
+  margin-top: 2rem;
+  color: var(--text-muted);
+}
+
+/* Lab */
+
+.lab {
+  padding: 4rem 0 5rem;
+}
+
+.lab__entries {
   display: grid;
   gap: 2.5rem;
-  align-items: start;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-.contact-form {
-  display: grid;
-  gap: 1.25rem;
-  padding: 2rem;
-  background: rgba(7, 8, 26, 0.75);
+.lab-entry {
+  background: var(--surface);
+  border: 1px solid var(--surface-highlight);
   border-radius: var(--radius);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: var(--shadow-soft);
-}
-
-.form-group {
+  padding: 2rem;
   display: grid;
-  gap: 0.5rem;
+  gap: 1.5rem;
 }
 
-.form-group--full {
-  grid-column: 1 / -1;
+.lab-entry__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-label {
+.lab-entry__meta,
+.lab-entry__date {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.lab-entry__details {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.lab-entry__details div {
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: calc(var(--radius) - 6px);
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.lab-entry__details dt {
   font-weight: 600;
   color: var(--text);
 }
 
-input,
-select,
-textarea {
-  padding: 0.85rem 1rem;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(12, 14, 38, 0.65);
-  color: var(--text);
-  font: inherit;
+.lab-entry__details dd {
+  margin: 0.4rem 0 0;
 }
 
-input::placeholder,
-textarea::placeholder {
-  color: rgba(244, 246, 255, 0.45);
+.lab-detail__header {
+  margin-bottom: 2rem;
 }
 
-input:focus,
-select:focus,
-textarea:focus {
-  outline: 2px solid rgba(108, 92, 231, 0.6);
-  border-color: transparent;
+.lab-detail__meta {
+  color: var(--text-muted);
 }
 
-.form-footnote {
-  font-size: 0.8rem;
-  color: rgba(244, 246, 255, 0.6);
-  margin: 0;
+.lab-detail__footer {
+  margin-top: 2rem;
+  color: var(--text-muted);
 }
 
-.site-footer {
-  padding: 3rem 0;
-  background: rgba(7, 8, 26, 0.95);
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+/* Projects */
+
+.projects {
+  padding: 4rem 0 5rem;
 }
 
-.footer-inner {
-  display: grid;
-  gap: 2rem;
-  align-items: start;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.footer-links ul {
-  display: grid;
-  gap: 0.75rem;
-  font-weight: 500;
-}
-
-.footer-meta {
-  margin-top: 1.5rem;
+.card--project .card__meta {
   display: grid;
   gap: 1rem;
-  color: rgba(244, 246, 255, 0.55);
+  font-size: 0.95rem;
+  color: var(--text-muted);
 }
 
-.social {
+.card__meta dt {
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* Tags */
+
+.tags {
+  padding: 4rem 0 5rem;
+}
+
+.tags__cloud {
   display: flex;
-  gap: 0.75rem;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 3rem;
 }
 
-.social a {
-  width: 32px;
-  height: 32px;
+.tags__groups {
   display: grid;
-  place-items: center;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  font-size: 0.75rem;
-  text-transform: uppercase;
+  gap: 2rem;
 }
 
-.social a:hover,
-.social a:focus {
-  border-color: rgba(255, 255, 255, 0.35);
+.tag-group {
+  background: var(--surface);
+  border: 1px solid var(--surface-highlight);
+  border-radius: var(--radius);
+  padding: 2rem;
 }
+
+/* Search */
+
+.search {
+  padding: 4rem 0 5rem;
+}
+
+.search__form {
+  background: var(--surface);
+  border: 1px solid var(--surface-highlight);
+  border-radius: var(--radius);
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+
+.search__label {
+  display: block;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+}
+
+#search-query {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--surface-highlight);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text);
+  font-size: 1rem;
+}
+
+#search-query:focus {
+  outline: 2px solid var(--accent);
+}
+
+.search__empty,
+.search__error {
+  color: var(--text-muted);
+}
+
+.search__list {
+  display: grid;
+  gap: 1rem;
+}
+
+.search__item a {
+  display: block;
+  background: var(--surface);
+  border: 1px solid var(--surface-highlight);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.search__item a:hover,
+.search__item a:focus {
+  border-color: var(--accent);
+  transform: translateY(-3px);
+}
+
+.search__item-title {
+  font-weight: 600;
+  display: block;
+}
+
+.search__item-desc {
+  color: var(--text-muted);
+  display: block;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.search__item-tags {
+  font-size: 0.85rem;
+  color: var(--accent);
+}
+
+/* Generic page layout */
+
+.page {
+  padding: 4rem 0 5rem;
+}
+
+.page__content {
+  background: var(--surface);
+  border: 1px solid var(--surface-highlight);
+  border-radius: var(--radius);
+  padding: 2rem;
+}
+
+/* Accessibility */
 
 .sr-only {
   position: absolute;
@@ -635,68 +683,46 @@ textarea:focus {
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
   border: 0;
 }
 
-@media (max-width: 768px) {
-  .site-nav {
-    position: absolute;
-    inset: 72px 1.5rem auto;
-    flex-direction: column;
-    align-items: flex-start;
-    padding: 1.5rem;
-    border-radius: 18px;
-    background: rgba(7, 8, 26, 0.95);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    box-shadow: var(--shadow-soft);
-    transform: scaleY(0);
-    transform-origin: top;
-    opacity: 0;
-    pointer-events: none;
-    transition: transform 0.2s ease, opacity 0.2s ease;
+/* Responsive */
+
+@media (max-width: 900px) {
+  .wiki__layout {
+    grid-template-columns: 1fr;
   }
 
-  .site-nav ul {
-    flex-direction: column;
-    width: 100%;
-  }
-
-  .site-nav .button--ghost {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .site-nav[data-open="true"] {
-    transform: scaleY(1);
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  .nav-toggle {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-  }
-
-  .header-inner {
-    position: relative;
+  .wiki__sidebar {
+    position: static;
+    order: -1;
   }
 }
 
-@media (max-width: 600px) {
-  .hero {
-    padding-top: 6rem;
-  }
-
-  .hero-actions {
+@media (max-width: 768px) {
+  .site-nav ul {
+    position: absolute;
+    inset: 70px 0 auto;
+    margin: 0;
+    padding: 1.5rem 0;
+    background: rgba(17, 18, 22, 0.95);
     flex-direction: column;
-    align-items: stretch;
+    align-items: flex-start;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    transform: translateY(-20px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
   }
 
-  .hero-visual .dashboard {
-    padding: 2rem;
+  .site-nav[data-open='true'] ul {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .nav-toggle {
+    display: block;
   }
 }

--- a/tags.html
+++ b/tags.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · Tags</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a href="wiki.html">Wiki</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="lab.html">Lab Notebook</a></li>
+          <li><a href="projects.html">Projects</a></li>
+          <li><a aria-current="page" href="tags.html">Tags</a></li>
+          <li><a href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="tags">
+    <div class="container">
+      <header class="page-header">
+        <p class="eyebrow">Vocabulary</p>
+        <h1>Tags</h1>
+        <p>A shared language applied across wiki, blog, lab, and project content.</p>
+      </header>
+
+      <section class="tags__cloud" aria-label="All tags">
+        <a class="tag" href="#tag-architecture">architecture</a>
+        <a class="tag" href="#tag-workflow">workflow</a>
+        <a class="tag" href="#tag-lab">lab</a>
+        <a class="tag" href="#tag-quality">quality</a>
+        <a class="tag" href="#tag-search">search</a>
+        <a class="tag" href="#tag-performance">performance</a>
+        <a class="tag" href="#tag-governance">governance</a>
+        <a class="tag" href="#tag-ux">ux</a>
+        <a class="tag" href="#tag-announcement">announcement</a>
+        <a class="tag" href="#tag-build">build</a>
+        <a class="tag" href="#tag-projects">projects</a>
+        <a class="tag" href="#tag-process">process</a>
+        <a class="tag" href="#tag-static">static</a>
+      </section>
+
+      <section class="tags__groups" aria-label="Tag details">
+        <article class="tag-group" id="tag-architecture">
+          <h2>architecture</h2>
+          <ul class="list">
+            <li><a href="wiki.html#foundations">Foundations</a> · Wiki</li>
+            <li><a href="projects.html#project-static-pipeline">Static pipeline hardening</a> · Project</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-workflow">
+          <h2>workflow</h2>
+          <ul class="list">
+            <li><a href="wiki.html#publishing">Publishing workflow</a> · Wiki</li>
+            <li><a href="blog/aligning-static-workflows.html">Aligning static workflows with research cadence</a> · Blog</li>
+            <li><a href="lab/landing-gate-usability.html">NR-LAB-004 · Landing gate usability scan</a> · Lab</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-lab">
+          <h2>lab</h2>
+          <ul class="list">
+            <li><a href="blog/aligning-static-workflows.html">Aligning static workflows with research cadence</a> · Blog</li>
+            <li><a href="blog/lab-index-release.html">Publishing the first unified lab index</a> · Blog</li>
+            <li><a href="lab/delta-observation-window.html">NR-LAB-006 · Delta observation window stress test</a> · Lab</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-quality">
+          <h2>quality</h2>
+          <ul class="list">
+            <li><a href="wiki.html#publishing">Publishing workflow</a> · Wiki</li>
+            <li><a href="blog/lab-index-release.html">Publishing the first unified lab index</a> · Blog</li>
+            <li><a href="lab/search-prototype-benchmark.html">NR-LAB-005 · Client-side search prototype benchmark</a> · Lab</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-search">
+          <h2>search</h2>
+          <ul class="list">
+            <li><a href="lab/search-prototype-benchmark.html">NR-LAB-005 · Client-side search prototype benchmark</a> · Lab</li>
+            <li><a href="projects.html#project-static-pipeline">Static pipeline hardening</a> · Project</li>
+            <li><a href="search.html">Search index</a> · Search</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-performance">
+          <h2>performance</h2>
+          <ul class="list">
+            <li><a href="lab/delta-observation-window.html">NR-LAB-006 · Delta observation window stress test</a> · Lab</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-governance">
+          <h2>governance</h2>
+          <ul class="list">
+            <li><a href="wiki.html#governance">Governance</a> · Wiki</li>
+            <li><a href="projects.html#project-knowledge-graph">Knowledge graph curation</a> · Project</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-ux">
+          <h2>ux</h2>
+          <ul class="list">
+            <li><a href="lab/landing-gate-usability.html">NR-LAB-004 · Landing gate usability scan</a> · Lab</li>
+            <li><a href="projects.html#project-landing-experience">Landing experience refresh</a> · Project</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-announcement">
+          <h2>announcement</h2>
+          <ul class="list">
+            <li><a href="blog/welcome.html">Welcome to Normal Rooms</a> · Blog</li>
+            <li><a href="projects.html#project-landing-experience">Landing experience refresh</a> · Project</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-build">
+          <h2>build</h2>
+          <ul class="list">
+            <li><a href="wiki.html#publishing">Publishing workflow</a> · Wiki</li>
+            <li><a href="projects.html#project-static-pipeline">Static pipeline hardening</a> · Project</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-projects">
+          <h2>projects</h2>
+          <ul class="list">
+            <li><a href="wiki.html#architecture">Architecture</a> · Wiki</li>
+            <li><a href="projects.html">Projects hub</a> · Projects</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-process">
+          <h2>process</h2>
+          <ul class="list">
+            <li><a href="wiki.html#governance">Governance</a> · Wiki</li>
+          </ul>
+        </article>
+
+        <article class="tag-group" id="tag-static">
+          <h2>static</h2>
+          <ul class="list">
+            <li><a href="wiki.html#architecture">Architecture</a> · Wiki</li>
+            <li><a href="blog/lab-index-release.html">Publishing the first unified lab index</a> · Blog</li>
+          </ul>
+        </article>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="donate.html">Support</a></li>
+          <li><a href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/wiki.html
+++ b/wiki.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Normal Rooms · Wiki</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="home.html">
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <span class="brand-text">Normal Rooms</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+      <nav id="primary-navigation" class="site-nav" data-open="false">
+        <ul>
+          <li><a aria-current="page" href="wiki.html">Wiki</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="lab.html">Lab Notebook</a></li>
+          <li><a href="projects.html">Projects</a></li>
+          <li><a href="tags.html">Tags</a></li>
+          <li><a href="search.html">Search</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="wiki">
+    <div class="container wiki__layout">
+      <aside class="wiki__sidebar" aria-label="Article navigation">
+        <h2 class="wiki__sidebar-title">Contents</h2>
+        <nav>
+          <ul>
+            <li><a href="#foundations">Foundations</a></li>
+            <li><a href="#architecture">Architecture</a></li>
+            <li><a href="#publishing">Publishing workflow</a></li>
+            <li><a href="#governance">Governance</a></li>
+          </ul>
+        </nav>
+      </aside>
+
+      <article class="wiki__content">
+        <header class="page-header">
+          <p class="eyebrow">Reference</p>
+          <h1>Wiki</h1>
+          <p>Evergreen, interlinked documentation for the Normal Rooms project.</p>
+        </header>
+
+        <section id="foundations" class="wiki__section">
+          <h2>Foundations</h2>
+          <p>
+            Normal Rooms is a static-first initiative that favors predictable deployments, human
+            readable URLs, and a single Markdown/MDX substrate. All content is rendered during the
+            build, ensuring the site remains fast on GitHub Pages without runtime dependencies.
+          </p>
+          <ul class="tag-list">
+            <li><a class="tag" href="tags.html#architecture">architecture</a></li>
+            <li><a class="tag" href="tags.html#workflow">workflow</a></li>
+          </ul>
+        </section>
+
+        <section id="architecture" class="wiki__section">
+          <h2>Architecture</h2>
+          <p>
+            The stack centers on Docusaurus conventions: docs, blog, and custom pages map to our
+            wiki, blog, and lab notebook idioms. Components are kept light to guarantee readability
+            without JavaScript. Navigation chrome is shared across all pages for consistency.
+          </p>
+          <p>
+            Projects are represented by dedicated MDX files that aggregate links via tags. Each
+            document may appear in multiple idioms by reference, avoiding duplicated truths while
+            supporting multi-entry navigation.
+          </p>
+          <ul class="tag-list">
+            <li><a class="tag" href="tags.html#static">static</a></li>
+            <li><a class="tag" href="tags.html#projects">projects</a></li>
+          </ul>
+        </section>
+
+        <section id="publishing" class="wiki__section">
+          <h2>Publishing workflow</h2>
+          <p>
+            Content authors work in a single repository folder structure mirroring Docusaurus docs,
+            blog posts, lab entries, and project hubs. Each file includes light front matter for
+            title, description, and tags. A build script generates the static site, local search
+            index, and integrity checks before deployment.
+          </p>
+          <p>
+            Because the build emits all pages, indexes, and search data, the public site serves only
+            static files. GitHub Pages hosts the result for free, and link stability checks catch
+            regressions before publishing.
+          </p>
+          <ul class="tag-list">
+            <li><a class="tag" href="tags.html#build">build</a></li>
+            <li><a class="tag" href="tags.html#quality">quality</a></li>
+          </ul>
+        </section>
+
+        <section id="governance" class="wiki__section">
+          <h2>Governance</h2>
+          <p>
+            A small shared vocabulary of tags keeps the site navigable. Project leads maintain the
+            taxonomy, review incoming documents, and ensure every change includes updated cross
+            references. Release notes appear on the blog, while decisions that affect policy land in
+            the wiki for permanent reference.
+          </p>
+          <p>
+            The lab notebook remains append-only to preserve experiment history. Projects link to
+            relevant lab entries and posts via tags, building a durable knowledge graph.
+          </p>
+          <ul class="tag-list">
+            <li><a class="tag" href="tags.html#governance">governance</a></li>
+            <li><a class="tag" href="tags.html#process">process</a></li>
+          </ul>
+        </section>
+      </article>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <span class="brand-mark" aria-hidden="true">NR</span>
+        <p>Static-first publishing for Normal Rooms.</p>
+      </div>
+      <nav aria-label="Footer links">
+        <ul class="footer__links">
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="donate.html">Support</a></li>
+          <li><a href="legal.html">Legal</a></li>
+        </ul>
+      </nav>
+      <p class="footer__meta">© <span id="year"></span> Normal Rooms. All static, all the time.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the single landing splash with a gray-and-orange gate that links into the new home hub
- add dedicated static pages for the wiki, blog, lab notebook, projects, tags, search, and required legal/support content
- wire up shared styling, navigation, and a prebuilt JSON search index consumed client-side across the site

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68fe9e40f010832b917177bc773eaff5