### PR TITLE
Refine styling to gray and orange palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,149 @@ npm test
 ```
 
 Each script can also be invoked individually (for example `npm run test:links`) if you want to focus on a specific check.
+
+## Content management
+
+Administrators can publish new material by editing the HTML fragments in `content/`, the lab notebook in `lab/`, and the JSON indexes in `data/`:
+
+- **Blog posts** live in `content/blog/`. Each entry must also be described in `data/blog/posts.json` so the module shell can surface it in listings.
+- **Wiki articles** live in `content/wiki/` with their metadata stored in `data/wiki/articles.json`.
+- **Project hubs** live in `content/projects/` with structure and spotlight links declared in `data/projects/projects.json`.
+- **Lab notes** live in `lab/`. They are linked directly from the lab index HTML and should receive a `data/search/index.json` entry so global search can find them.
+
+After adding or renaming a document, update `data/search/index.json` with a concise summary and the correct module URL. This keeps the search dialog synchronized with the published surfaces.
+
+## Template reference
+
+Use the following snippets as copy-ready starting points when adding new content. Replace placeholder values before publishing and mirror the metadata in the appropriate JSON files.
+
+### Metadata snippets
+
+**Blog post (`data/blog/posts.json`)**
+
+```json
+{
+  "slug": "your-slug",
+  "title": "Readable Title",
+  "date": "YYYY-MM-DD",
+  "type": "Announcement",
+  "summary": "One-sentence description that fits in cards and search results.",
+  "contentPath": "content/blog/your-slug.html",
+  "tags": ["tag-one", "tag-two"]
+}
+```
+
+**Wiki article (`data/wiki/articles.json`)**
+
+```json
+{
+  "id": "concise-id",
+  "title": "Article title",
+  "subtitle": "Short descriptor",
+  "summary": "Single-sentence overview for cards and search.",
+  "contentPath": "content/wiki/concise-id.html",
+  "updated": "YYYY-MM-DD"
+}
+```
+
+**Project hub (`data/projects/projects.json`)**
+
+```json
+{
+  "slug": "project-slug",
+  "title": "Project title",
+  "domain": "Knowledge graph",
+  "sequence": 1,
+  "summary": "Focused blurb describing the project scope.",
+  "updated": "YYYY-MM-DD",
+  "tags": ["workflow", "quality"],
+  "contentPath": "content/projects/project-slug.html",
+  "spotlight": [
+    {"label": "Wiki", "title": "Related article", "url": "../wiki/article.html?doc=concise-id"},
+    {"label": "Blog", "title": "Release notes", "url": "../blog/post.html?slug=your-slug"}
+  ]
+}
+```
+
+Add the new object to the existing array in the JSON file and maintain chronological ordering when relevant.
+
+### Document scaffolds
+
+**Atomic document authoring template** – create a Markdown file with YAML front matter while drafting, then convert the body to HTML before saving it in `content/` or `lab/`.
+
+```markdown
+---
+title: Document title
+summary: A short description used in search and cards
+updated: YYYY-MM-DD
+tags:
+  - tag-one
+  - tag-two
+---
+
+## Opening statement
+
+Describe the context for the work.
+
+## Key details
+
+- Capture critical facts in list form.
+- Reference related wiki articles or projects with descriptive link text.
+
+## Next steps
+
+Outline follow-up tasks or open questions.
+```
+
+When you paste the final HTML into `content/`, keep the YAML block in an HTML comment at the top if you want to preserve the metadata for future edits:
+
+```html
+<!--
+---
+title: Document title
+summary: A short description used in search and cards
+updated: YYYY-MM-DD
+tags:
+  - tag-one
+  - tag-two
+---
+-->
+
+<section>
+  <h2>Opening statement</h2>
+  <p>Describe the context for the work.</p>
+  <h2>Key details</h2>
+  <ul>
+    <li>Capture critical facts in list form.</li>
+    <li>Reference related wiki articles or projects with descriptive link text.</li>
+  </ul>
+  <h2>Next steps</h2>
+  <p>Outline follow-up tasks or open questions.</p>
+</section>
+```
+
+**Project hub content skeleton (`content/projects/*.html`)**
+
+```html
+<header class="project-card__header">
+  <h1>Project title</h1>
+  <p class="project-card__summary">One sentence that conveys scope and progress.</p>
+</header>
+<section>
+  <h2>Objectives</h2>
+  <ul>
+    <li>Primary outcome number one.</li>
+    <li>Primary outcome number two.</li>
+  </ul>
+</section>
+<section>
+  <h2>Milestones</h2>
+  <p>Call out recent releases or checkpoints.</p>
+</section>
+```
+
+### Linking guidelines
+
+- Use relative URLs so the static site works when browsed locally (for example `../wiki/article.html?doc=architecture-overview`).
+- Prefer descriptive link text over raw URLs.
+- Mirror any new links in the search index when they introduce a new concept or surface.

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,14 +1,18 @@
 :root {
-  --bg: #111216;
-  --bg-alt: #16171d;
-  --surface: rgba(255, 255, 255, 0.04);
-  --surface-strong: rgba(255, 255, 255, 0.12);
-  --surface-highlight: rgba(255, 255, 255, 0.12);
-  --text: #f6f7f9;
-  --text-muted: rgba(246, 247, 249, 0.72);
-  --accent: #ff773f;
-  --accent-soft: rgba(255, 119, 63, 0.12);
-  --accent-strong: rgba(255, 119, 63, 0.24);
+  --bg: #f5f6f7;
+  --bg-alt: #eceff1;
+  --surface: #ffffff;
+  --surface-muted: #f7f8f9;
+  --surface-strong: #e0e5ea;
+  --surface-highlight: #fff3ec;
+  --text: #20242a;
+  --text-muted: rgba(32, 36, 42, 0.7);
+  --accent: #ff6a3d;
+  --accent-soft: rgba(255, 106, 61, 0.12);
+  --accent-strong: rgba(255, 106, 61, 0.24);
+  --border-subtle: rgba(32, 36, 42, 0.1);
+  --border-strong: rgba(32, 36, 42, 0.18);
+  --shadow-soft: 0 18px 40px rgba(18, 21, 26, 0.12);
   --radius: 12px;
   --font: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
@@ -50,7 +54,7 @@ img {
 
 .section {
   padding: 4.5rem 0;
-  border-top: 1px solid rgba(246, 247, 249, 0.08);
+  border-top: 1px solid var(--border-subtle);
 }
 
 .section:first-of-type {
@@ -131,11 +135,11 @@ ul {
 .button:hover,
 .button:focus {
   background: var(--accent);
-  color: var(--bg);
+  color: #fff;
 }
 
 .button--ghost {
-  border-color: rgba(246, 247, 249, 0.32);
+  border-color: var(--border-strong);
   color: var(--text);
 }
 
@@ -149,8 +153,9 @@ ul {
   top: 0;
   z-index: 20;
   backdrop-filter: blur(18px);
-  background: rgba(17, 18, 22, 0.82);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(245, 246, 247, 0.92);
+  border-bottom: 1px solid var(--border-subtle);
+  box-shadow: 0 10px 30px rgba(18, 21, 26, 0.08);
 }
 
 .header-inner {
@@ -258,7 +263,7 @@ ul {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  border-bottom: 1px solid rgba(246, 247, 249, 0.08);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .card__link {
@@ -298,10 +303,10 @@ ul {
 }
 
 .site-footer {
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--border-subtle);
   padding: 3rem 0;
   margin-top: 4rem;
-  background: rgba(17, 18, 22, 0.82);
+  background: var(--bg-alt);
 }
 
 .footer__inner {
@@ -330,8 +335,7 @@ ul {
   min-height: 100vh;
   display: grid;
   place-items: center;
-  background: radial-gradient(circle at top left, rgba(255, 119, 63, 0.18), transparent 45%),
-    radial-gradient(circle at bottom right, rgba(255, 119, 63, 0.12), transparent 45%), var(--bg);
+  background: linear-gradient(135deg, var(--bg) 0%, var(--surface-muted) 100%);
 }
 
 .landing__wrap {
@@ -339,11 +343,12 @@ ul {
 }
 
 .landing__frame {
-  border: 1px solid rgba(246, 247, 249, 0.08);
+  border: 1px solid var(--border-subtle);
   border-radius: calc(var(--radius) + 4px);
   padding: 3rem;
-  background: rgba(17, 18, 22, 0.82);
+  background: var(--surface);
   text-align: left;
+  box-shadow: var(--shadow-soft);
 }
 
 .landing__tag {
@@ -389,7 +394,7 @@ ul {
   padding: 0 0 2.5rem;
   display: grid;
   gap: 1.5rem;
-  border-bottom: 1px solid rgba(246, 247, 249, 0.08);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .lab-entry__header {
@@ -411,7 +416,7 @@ ul {
 
 .lab-entry__details div {
   padding: 0.75rem 0;
-  border-bottom: 1px solid rgba(246, 247, 249, 0.08);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .lab-entry__details dt {
@@ -474,7 +479,7 @@ ul {
 
 .tag-group {
   padding: 0 0 2.5rem;
-  border-bottom: 1px solid rgba(246, 247, 249, 0.08);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 /* Search */
@@ -486,7 +491,7 @@ ul {
 .search__form {
   padding: 0 0 2rem;
   margin-bottom: 2rem;
-  border-bottom: 1px solid rgba(246, 247, 249, 0.08);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .search__label {
@@ -499,7 +504,7 @@ ul {
   width: 100%;
   padding: 0.75rem 1rem;
   border-radius: 8px;
-  border: 1px solid rgba(246, 247, 249, 0.18);
+  border: 1px solid var(--border-strong);
   background: transparent;
   color: var(--text);
   font-size: 1rem;
@@ -522,7 +527,7 @@ ul {
 .search__item a {
   display: block;
   padding: 1.25rem 0;
-  border-bottom: 1px solid rgba(246, 247, 249, 0.08);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .search__item-title {
@@ -578,7 +583,7 @@ ul {
     order: -1;
     padding: 0 0 1.5rem;
     border-left: none;
-    border-bottom: 1px solid rgba(246, 247, 249, 0.08);
+    border-bottom: 1px solid var(--border-subtle);
   }
 }
 
@@ -588,11 +593,11 @@ ul {
     inset: 70px 0 auto;
     margin: 0;
     padding: 1.5rem 0;
-    background: rgba(17, 18, 22, 0.95);
+    background: rgba(255, 255, 255, 0.98);
     flex-direction: column;
     align-items: flex-start;
     gap: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid var(--border-subtle);
     transform: translateY(-20px);
     opacity: 0;
     pointer-events: none;

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -78,7 +78,7 @@ body.skin-blog a:focus {
 .blog-footer__inner {
   max-width: var(--module-max-width);
   margin: 0 auto;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--border-subtle);
   padding-top: 1.5rem;
   font-size: 0.9rem;
   color: var(--text-muted);

--- a/assets/css/modules.css
+++ b/assets/css/modules.css
@@ -10,9 +10,9 @@ body[class*='skin-'] {
 
 .module-hero {
   padding: clamp(3rem, 7vw, 5rem) 1.5rem;
-  background: radial-gradient(circle at top left, rgba(255, 119, 63, 0.18), transparent 55%),
-    linear-gradient(135deg, rgba(255, 255, 255, 0.05) 0%, rgba(17, 18, 22, 0.65) 100%);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(140deg, var(--surface) 0%, var(--surface-muted) 100%);
+  border-bottom: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-soft);
 }
 
 .module-hero__inner {
@@ -70,8 +70,8 @@ body[class*='skin-'] {
 }
 
 .module-search input[type='search'] {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
   border-radius: 999px;
   padding: 0.85rem 1.25rem;
   color: var(--text);
@@ -81,13 +81,13 @@ body[class*='skin-'] {
 }
 
 .module-search input[type='search']::placeholder {
-  color: rgba(246, 247, 249, 0.4);
+  color: rgba(32, 36, 42, 0.45);
 }
 
 .module-search input[type='search']:focus {
   outline: none;
-  border-color: rgba(255, 119, 63, 0.55);
-  box-shadow: 0 0 0 3px rgba(255, 119, 63, 0.25);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .module-shell {
@@ -99,8 +99,8 @@ body[class*='skin-'] {
 }
 
 .module-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius);
   padding: clamp(1.5rem, 3vw, 2rem);
   display: grid;
@@ -111,8 +111,8 @@ body[class*='skin-'] {
 .module-card:hover,
 .module-card:focus-within {
   transform: translateY(-4px);
-  border-color: rgba(255, 119, 63, 0.45);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+  border-color: var(--accent);
+  box-shadow: var(--shadow-soft);
 }
 
 .module-card__meta {
@@ -154,8 +154,8 @@ body[class*='skin-'] {
 }
 
 .module-sidebar section {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius);
   padding: clamp(1.25rem, 2.5vw, 1.75rem);
 }
@@ -212,10 +212,11 @@ body[class*='skin-'] {
 .module-detail {
   display: grid;
   gap: clamp(1.75rem, 3vw, 2.5rem);
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius);
   padding: clamp(2rem, 4vw, 3rem);
+  box-shadow: var(--shadow-soft);
 }
 
 .module-detail header {
@@ -259,7 +260,7 @@ body[class*='skin-'] {
 }
 
 .tag-list .tag {
-  border: 1px solid rgba(255, 255, 255, 0.16);
+  border: 1px solid var(--border-strong);
   border-radius: 999px;
   padding: 0.25rem 0.75rem;
   font-size: 0.8rem;
@@ -268,7 +269,7 @@ body[class*='skin-'] {
 
 .tag-list .tag:hover,
 .tag-list .tag:focus {
-  border-color: rgba(255, 119, 63, 0.6);
+  border-color: var(--accent);
   color: var(--accent);
 }
 

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -8,8 +8,8 @@ body.skin-projects a:focus {
 }
 
 #projects-stack > .module-stack__domain {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius);
   padding: clamp(1.5rem, 3vw, 2rem);
 }
@@ -66,7 +66,7 @@ body.skin-projects a:focus {
 .project-card__spotlight {
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--border-subtle);
 }
 
 .project-card__spotlight p {
@@ -114,7 +114,7 @@ body.skin-projects a:focus {
 .projects-footer__inner {
   max-width: var(--module-max-width);
   margin: 0 auto;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--border-subtle);
   padding-top: 1.5rem;
   font-size: 0.9rem;
   color: var(--text-muted);

--- a/assets/css/wiki.css
+++ b/assets/css/wiki.css
@@ -28,10 +28,11 @@ body.skin-wiki h3 {
 .wiki-sidebar {
   display: grid;
   gap: 1rem;
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius);
   padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  box-shadow: var(--shadow-soft);
 }
 
 .wiki-sidebar h2 {
@@ -58,11 +59,11 @@ body.skin-wiki h3 {
 .wiki-main {
   display: grid;
   gap: clamp(1.5rem, 3vw, 2rem);
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius);
   padding: clamp(2rem, 4vw, 3rem);
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--shadow-soft);
 }
 
 .wiki-tabs {
@@ -71,7 +72,7 @@ body.skin-wiki h3 {
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid var(--border-subtle);
   padding-bottom: 0.75rem;
 }
 
@@ -90,12 +91,12 @@ body.skin-wiki h3 {
   padding: 0.35rem 0.85rem;
   border-radius: 999px;
   font-size: 0.85rem;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-muted);
   color: var(--text-muted);
 }
 
 .wiki-tabs .active {
-  background: rgba(255, 119, 63, 0.2);
+  background: var(--accent-soft);
   color: var(--accent);
   font-weight: 600;
 }
@@ -113,7 +114,7 @@ body.skin-wiki h3 {
   font-size: clamp(1.4rem, 3vw, 1.85rem);
   margin-top: clamp(1.75rem, 3vw, 2.5rem);
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .wiki-article h3 {
@@ -135,7 +136,7 @@ body.skin-wiki h3 {
 }
 
 .wiki-related {
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--border-subtle);
   padding-top: 1.5rem;
   display: grid;
   gap: 1rem;
@@ -164,8 +165,8 @@ body.skin-wiki h3 {
 }
 
 .wiki-toc {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius);
   padding: clamp(1.25rem, 2.5vw, 1.75rem);
   position: sticky;
@@ -173,6 +174,7 @@ body.skin-wiki h3 {
   display: grid;
   gap: 1rem;
   height: fit-content;
+  box-shadow: var(--shadow-soft);
 }
 
 .wiki-toc h2 {
@@ -205,7 +207,7 @@ body.skin-wiki h3 {
 .wiki-footer__inner {
   max-width: var(--module-max-width);
   margin: 0 auto;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--border-subtle);
   padding-top: 1.5rem;
   color: var(--text-muted);
   display: grid;


### PR DESCRIPTION
## Summary
- restyle the shared layout and module surfaces around a light gray base with an orange accent palette
- refresh module, blog, project, and wiki styles so cards and sidebars sit on clean surfaces
- document how to add new content with JSON snippets, authoring templates, and linking guidance in the README

## Testing
- npm test *(fails: missing jsdom dependency in local test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68fecc0568c4832b8d19e744334bccb1