### PR TITLE
Automate document metadata and unify visual system

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,68 +33,47 @@ Each script can also be invoked individually (for example `npm run test:links`) 
 
 ## Content management
 
-Administrators can publish new material by editing the HTML fragments in `content/`, the lab notebook in `lab/`, and the JSON indexes in `data/`:
+Documents are authored as HTML files in `content/` or `lab/` with a JSON front matter block stored in a leading HTML comment. Drop a new file into the correct folder, keep the front matter up to date, and run `npm run build:documents` (automatically executed before `npm test`). The build script reads every document, generates the module indexes in `data/`, and refreshes the global search payload. No manual JSON editing is required.
 
-- **Blog posts** live in `content/blog/`. Each entry must also be described in `data/blog/posts.json` so the module shell can surface it in listings.
-- **Wiki articles** live in `content/wiki/` with their metadata stored in `data/wiki/articles.json`.
-- **Project hubs** live in `content/projects/` with structure and spotlight links declared in `data/projects/projects.json`.
-- **Lab notes** live in `lab/`. They are linked directly from the lab index HTML and should receive a `data/search/index.json` entry so global search can find them.
+Each document declares the surfaces it should appear on:
 
-After adding or renaming a document, update `data/search/index.json` with a concise summary and the correct module URL. This keeps the search dialog synchronized with the published surfaces.
+- **Blog posts** belong in `content/blog/` and include `"blog"` metadata (slug, date, type, tags).
+- **Wiki articles** live in `content/wiki/` with `"wiki"` metadata (id, subtitle, updated).
+- **Project hubs** live in `content/projects/` with `"projects"` metadata (slug, domain, sequence, tags, spotlight links).
+- **Lab notes** remain in `lab/` and can opt into search by providing `"lab"` metadata with a canonical URL.
+
+Any document can opt into the global search index by providing a `"search"` surface with a description and tags. URLs for blog, wiki, and project surfaces are inferred automatically.
 
 ## Template reference
 
-Use the following snippets as copy-ready starting points when adding new content. Replace placeholder values before publishing and mirror the metadata in the appropriate JSON files.
+Use the following snippets as copy-ready starting points when adding new content. Replace placeholder values before publishing.
 
-### Metadata snippets
+### Front matter reference
 
-**Blog post (`data/blog/posts.json`)**
+**Document comment with JSON front matter**
 
-```json
+```html
+<!--
 {
-  "slug": "your-slug",
-  "title": "Readable Title",
-  "date": "YYYY-MM-DD",
-  "type": "Announcement",
-  "summary": "One-sentence description that fits in cards and search results.",
-  "contentPath": "content/blog/your-slug.html",
-  "tags": ["tag-one", "tag-two"]
+  "title": "Document title",
+  "summary": "A short description used in search and cards.",
+  "surfaces": {
+    "blog": {
+      "slug": "your-slug",
+      "date": "YYYY-MM-DD",
+      "type": "Announcement",
+      "tags": ["tag-one", "tag-two"]
+    },
+    "search": {
+      "description": "One-sentence description that fits in cards and search results.",
+      "tags": ["blog", "announcement"]
+    }
+  }
 }
+-->
 ```
 
-**Wiki article (`data/wiki/articles.json`)**
-
-```json
-{
-  "id": "concise-id",
-  "title": "Article title",
-  "subtitle": "Short descriptor",
-  "summary": "Single-sentence overview for cards and search.",
-  "contentPath": "content/wiki/concise-id.html",
-  "updated": "YYYY-MM-DD"
-}
-```
-
-**Project hub (`data/projects/projects.json`)**
-
-```json
-{
-  "slug": "project-slug",
-  "title": "Project title",
-  "domain": "Knowledge graph",
-  "sequence": 1,
-  "summary": "Focused blurb describing the project scope.",
-  "updated": "YYYY-MM-DD",
-  "tags": ["workflow", "quality"],
-  "contentPath": "content/projects/project-slug.html",
-  "spotlight": [
-    {"label": "Wiki", "title": "Related article", "url": "../wiki/article.html?doc=concise-id"},
-    {"label": "Blog", "title": "Release notes", "url": "../blog/post.html?slug=your-slug"}
-  ]
-}
-```
-
-Add the new object to the existing array in the JSON file and maintain chronological ordering when relevant.
+Add or remove surfaces as needed. The build script infers URLs for blog, wiki, and project surfaces and respects an explicit `url` field when present (for example, lab notes).
 
 ### Document scaffolds
 
@@ -124,32 +103,7 @@ Describe the context for the work.
 Outline follow-up tasks or open questions.
 ```
 
-When you paste the final HTML into `content/`, keep the YAML block in an HTML comment at the top if you want to preserve the metadata for future edits:
-
-```html
-<!--
----
-title: Document title
-summary: A short description used in search and cards
-updated: YYYY-MM-DD
-tags:
-  - tag-one
-  - tag-two
----
--->
-
-<section>
-  <h2>Opening statement</h2>
-  <p>Describe the context for the work.</p>
-  <h2>Key details</h2>
-  <ul>
-    <li>Capture critical facts in list form.</li>
-    <li>Reference related wiki articles or projects with descriptive link text.</li>
-  </ul>
-  <h2>Next steps</h2>
-  <p>Outline follow-up tasks or open questions.</p>
-</section>
-```
+When you paste the final HTML into `content/`, keep the JSON front matter comment at the top so the build script can parse it.
 
 **Project hub content skeleton (`content/projects/*.html`)**
 

--- a/about.html
+++ b/about.html
@@ -4,12 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Normal Rooms · About</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="assets/css/base.css" />
 </head>
 <body>

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 :root {
   --bg: #f5f6f7;
   --bg-alt: #eceff1;
@@ -14,7 +16,8 @@
   --border-strong: rgba(32, 36, 42, 0.18);
   --shadow-soft: 0 18px 40px rgba(18, 21, 26, 0.12);
   --radius: 12px;
-  --font: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font: 'Inter', 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --heading-font: 'Inter', 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 * {
@@ -90,6 +93,7 @@ h1,
 h2,
 h3,
 h4 {
+  font-family: var(--heading-font);
   font-weight: 600;
   line-height: 1.2;
   margin: 0 0 1rem;

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -1,12 +1,3 @@
-body.skin-blog a {
-  color: var(--accent);
-}
-
-body.skin-blog a:hover,
-body.skin-blog a:focus {
-  color: #ffa47a;
-}
-
 .blog-list ul {
   list-style: none;
   padding: 0;

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -1,12 +1,3 @@
-body.skin-projects a {
-  color: var(--accent);
-}
-
-body.skin-projects a:hover,
-body.skin-projects a:focus {
-  color: #ffa47a;
-}
-
 #projects-stack > .module-stack__domain {
   background: var(--surface);
   border: 1px solid var(--border-subtle);

--- a/assets/css/wiki.css
+++ b/assets/css/wiki.css
@@ -1,19 +1,3 @@
-body.skin-wiki a {
-  color: var(--accent);
-}
-
-body.skin-wiki a:hover,
-body.skin-wiki a:focus {
-  color: #ffa47a;
-}
-
-body.skin-wiki h1,
-body.skin-wiki h2,
-body.skin-wiki h3 {
-  font-family: 'Linux Libertine', 'Georgia', serif;
-  font-weight: 400;
-}
-
 .wiki-shell {
   display: grid;
   gap: clamp(1.5rem, 3vw, 2.5rem);

--- a/contact.html
+++ b/contact.html
@@ -4,12 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Normal Rooms · Contact</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="assets/css/base.css" />
 </head>
 <body>

--- a/content/blog/aligning-static-workflows.html
+++ b/content/blog/aligning-static-workflows.html
@@ -1,3 +1,21 @@
+<!--
+{
+  "title": "Aligning static workflows with research cadence",
+  "summary": "We consolidated the publishing workflow with the lab schedule so new findings reach every surface.",
+  "surfaces": {
+    "blog": {
+      "slug": "aligning-static-workflows",
+      "date": "2024-05-24",
+      "type": "Update",
+      "tags": ["workflow", "lab"]
+    },
+    "search": {
+      "description": "Synchronizing lab entries with wiki and project updates.",
+      "tags": ["blog", "workflow", "lab"]
+    }
+  }
+}
+-->
 <header class="blog-post__header">
   <h1>Aligning static workflows with research cadence</h1>
   <p class="post-meta">May 24, 2024 · Update</p>

--- a/content/blog/lab-index-release.html
+++ b/content/blog/lab-index-release.html
@@ -1,3 +1,21 @@
+<!--
+{
+  "title": "Publishing the first unified lab index",
+  "summary": "The lab index ships with static search data and cross-links for experiment traceability.",
+  "surfaces": {
+    "blog": {
+      "slug": "lab-index-release",
+      "date": "2024-05-10",
+      "type": "Release",
+      "tags": ["lab", "quality"]
+    },
+    "search": {
+      "description": "Launching the lab notebook index and static search payload.",
+      "tags": ["blog", "lab", "quality"]
+    }
+  }
+}
+-->
 <header class="blog-post__header">
   <h1>Publishing the first unified lab index</h1>
   <p class="post-meta">May 10, 2024 · Release</p>

--- a/content/blog/welcome.html
+++ b/content/blog/welcome.html
@@ -1,3 +1,21 @@
+<!--
+{
+  "title": "Welcome to Normal Rooms",
+  "summary": "Introducing the Normal Rooms knowledge hub and its documentation idioms.",
+  "surfaces": {
+    "blog": {
+      "slug": "welcome",
+      "date": "2024-04-18",
+      "type": "Announcement",
+      "tags": ["announcement"]
+    },
+    "search": {
+      "description": "Introducing the Normal Rooms knowledge hub and its documentation idioms.",
+      "tags": ["blog", "announcement"]
+    }
+  }
+}
+-->
 <header class="blog-post__header">
   <h1>Welcome to Normal Rooms</h1>
   <p class="post-meta">April 18, 2024 · Announcement</p>

--- a/content/projects/knowledge-graph-curation.html
+++ b/content/projects/knowledge-graph-curation.html
@@ -1,3 +1,31 @@
+<!--
+{
+  "title": "Knowledge graph curation",
+  "summary": "Establish a sustainable taxonomy for wiki topics, experiment IDs, and project identifiers to keep cross-linking accurate.",
+  "surfaces": {
+    "projects": {
+      "slug": "knowledge-graph-curation",
+      "domain": {
+        "name": "Knowledge graph",
+        "description": "Taxonomy, governance, and relational structure for the knowledge base.",
+        "order": 2
+      },
+      "sequence": 1,
+      "updated": "2024-05-20",
+      "tags": ["governance", "workflow"],
+      "spotlight": [
+        {"label": "Wiki", "title": "Architecture overview", "url": "../wiki/article.html?doc=architecture-overview"},
+        {"label": "Blog", "title": "Welcome to Normal Rooms", "url": "../blog/post.html?slug=welcome"},
+        {"label": "Log", "title": "NR-LAB-004 landing gate study", "url": "../../lab/landing-gate-usability.html"}
+      ]
+    },
+    "search": {
+      "description": "Taxonomy stewardship for tags, projects, and experiments.",
+      "tags": ["project", "governance", "workflow"]
+    }
+  }
+}
+-->
 <section>
   <h2>Focus</h2>
   <p>

--- a/content/projects/landing-experience-refresh.html
+++ b/content/projects/landing-experience-refresh.html
@@ -1,3 +1,31 @@
+<!--
+{
+  "title": "Landing experience refresh",
+  "summary": "Maintain a calm gray-and-orange entry point that sets the tone while keeping access frictionless across devices.",
+  "surfaces": {
+    "projects": {
+      "slug": "landing-experience-refresh",
+      "domain": {
+        "name": "Experience",
+        "description": "Presentation, interaction, and entry-point experiments for the site.",
+        "order": 3
+      },
+      "sequence": 1,
+      "updated": "2024-04-29",
+      "tags": ["ux", "workflow"],
+      "spotlight": [
+        {"label": "Wiki", "title": "Normal Rooms overview", "url": "../wiki/article.html?doc=normal-rooms"},
+        {"label": "Blog", "title": "Lab index release", "url": "../blog/post.html?slug=lab-index-release"},
+        {"label": "Log", "title": "NR-LAB-004 landing gate study", "url": "../../lab/landing-gate-usability.html"}
+      ]
+    },
+    "search": {
+      "description": "Maintaining the gray-and-orange gate experience.",
+      "tags": ["project", "ux", "workflow"]
+    }
+  }
+}
+-->
 <section>
   <h2>Focus</h2>
   <p>

--- a/content/projects/static-pipeline-hardening.html
+++ b/content/projects/static-pipeline-hardening.html
@@ -1,3 +1,31 @@
+<!--
+{
+  "title": "Static pipeline hardening",
+  "summary": "Fortify the static build pipeline with reproducible checks so every deploy ships with fresh search data and validated links.",
+  "surfaces": {
+    "projects": {
+      "slug": "static-pipeline-hardening",
+      "domain": {
+        "name": "Infrastructure",
+        "description": "Systems work that keeps the static pipeline resilient and observable.",
+        "order": 1
+      },
+      "sequence": 1,
+      "updated": "2024-05-24",
+      "tags": ["build", "quality"],
+      "spotlight": [
+        {"label": "Wiki", "title": "Publishing checklist", "url": "../wiki/article.html?doc=publishing-checklist"},
+        {"label": "Blog", "title": "Aligning static workflows", "url": "../blog/post.html?slug=aligning-static-workflows"},
+        {"label": "Log", "title": "NR-LAB-005 search benchmark", "url": "../../lab/search-prototype-benchmark.html"}
+      ]
+    },
+    "search": {
+      "description": "Project hub connecting build improvements across idioms.",
+      "tags": ["project", "build", "quality"]
+    }
+  }
+}
+-->
 <section>
   <h2>Focus</h2>
   <p>

--- a/content/wiki/architecture-overview.html
+++ b/content/wiki/architecture-overview.html
@@ -1,3 +1,20 @@
+<!--
+{
+  "title": "Architecture overview",
+  "summary": "How the static modules, assets, and content directories compose the site.",
+  "surfaces": {
+    "wiki": {
+      "id": "architecture-overview",
+      "subtitle": "Technical reference",
+      "updated": "2024-05-20"
+    },
+    "search": {
+      "description": "How modules, content, and assets compose the static knowledge base.",
+      "tags": ["wiki", "architecture", "reference"]
+    }
+  }
+}
+-->
 <header class="wiki-article__header">
   <h1>Architecture overview</h1>
   <p class="wiki-article__meta">Scope: Technical reference · Status: Stable</p>

--- a/content/wiki/normal-rooms.html
+++ b/content/wiki/normal-rooms.html
@@ -1,3 +1,20 @@
+<!--
+{
+  "title": "Normal Rooms",
+  "summary": "Overview of the Normal Rooms documentation stack and navigation patterns.",
+  "surfaces": {
+    "wiki": {
+      "id": "normal-rooms",
+      "subtitle": "Static-first knowledge base",
+      "updated": "2024-05-24"
+    },
+    "search": {
+      "description": "Overview of the Normal Rooms documentation stack and navigation patterns.",
+      "tags": ["wiki", "architecture", "workflow"]
+    }
+  }
+}
+-->
 <header class="wiki-article__header">
   <h1>Normal Rooms</h1>
   <p class="wiki-article__subtitle">Static-first knowledge base, configured by relation.</p>

--- a/content/wiki/publishing-checklist.html
+++ b/content/wiki/publishing-checklist.html
@@ -1,3 +1,20 @@
+<!--
+{
+  "title": "Publishing checklist",
+  "summary": "Step-by-step tasks for preparing and shipping documentation updates.",
+  "surfaces": {
+    "wiki": {
+      "id": "publishing-checklist",
+      "subtitle": "Release management",
+      "updated": "2024-05-18"
+    },
+    "search": {
+      "description": "Step-by-step guide for preparing documentation releases.",
+      "tags": ["wiki", "workflow", "quality"]
+    }
+  }
+}
+-->
 <header class="wiki-article__header">
   <h1>Publishing checklist</h1>
   <p class="wiki-article__meta">Scope: Release management · Status: Draft</p>

--- a/data/blog/posts.json
+++ b/data/blog/posts.json
@@ -7,7 +7,10 @@
       "type": "Update",
       "summary": "We consolidated the publishing workflow with the lab schedule so new findings reach every surface.",
       "contentPath": "content/blog/aligning-static-workflows.html",
-      "tags": ["workflow", "lab"]
+      "tags": [
+        "workflow",
+        "lab"
+      ]
     },
     {
       "slug": "lab-index-release",
@@ -16,7 +19,10 @@
       "type": "Release",
       "summary": "The lab index ships with static search data and cross-links for experiment traceability.",
       "contentPath": "content/blog/lab-index-release.html",
-      "tags": ["lab", "quality"]
+      "tags": [
+        "lab",
+        "quality"
+      ]
     },
     {
       "slug": "welcome",
@@ -25,7 +31,9 @@
       "type": "Announcement",
       "summary": "Introducing the Normal Rooms knowledge hub and its documentation idioms.",
       "contentPath": "content/blog/welcome.html",
-      "tags": ["announcement"]
+      "tags": [
+        "announcement"
+      ]
     }
   ]
 }

--- a/data/projects/projects.json
+++ b/data/projects/projects.json
@@ -21,12 +21,27 @@
       "sequence": 1,
       "summary": "Fortify the static build pipeline with reproducible checks so every deploy ships with fresh search data and validated links.",
       "updated": "2024-05-24",
-      "tags": ["build", "quality"],
+      "tags": [
+        "build",
+        "quality"
+      ],
       "contentPath": "content/projects/static-pipeline-hardening.html",
       "spotlight": [
-        {"label": "Wiki", "title": "Publishing checklist", "url": "../wiki/article.html?doc=publishing-checklist"},
-        {"label": "Blog", "title": "Aligning static workflows", "url": "../blog/post.html?slug=aligning-static-workflows"},
-        {"label": "Log", "title": "NR-LAB-005 search benchmark", "url": "../../lab/search-prototype-benchmark.html"}
+        {
+          "label": "Wiki",
+          "title": "Publishing checklist",
+          "url": "../wiki/article.html?doc=publishing-checklist"
+        },
+        {
+          "label": "Blog",
+          "title": "Aligning static workflows",
+          "url": "../blog/post.html?slug=aligning-static-workflows"
+        },
+        {
+          "label": "Log",
+          "title": "NR-LAB-005 search benchmark",
+          "url": "../../lab/search-prototype-benchmark.html"
+        }
       ]
     },
     {
@@ -36,12 +51,27 @@
       "sequence": 1,
       "summary": "Establish a sustainable taxonomy for wiki topics, experiment IDs, and project identifiers to keep cross-linking accurate.",
       "updated": "2024-05-20",
-      "tags": ["governance", "workflow"],
+      "tags": [
+        "governance",
+        "workflow"
+      ],
       "contentPath": "content/projects/knowledge-graph-curation.html",
       "spotlight": [
-        {"label": "Wiki", "title": "Architecture overview", "url": "../wiki/article.html?doc=architecture-overview"},
-        {"label": "Blog", "title": "Welcome to Normal Rooms", "url": "../blog/post.html?slug=welcome"},
-        {"label": "Log", "title": "NR-LAB-004 landing gate study", "url": "../../lab/landing-gate-usability.html"}
+        {
+          "label": "Wiki",
+          "title": "Architecture overview",
+          "url": "../wiki/article.html?doc=architecture-overview"
+        },
+        {
+          "label": "Blog",
+          "title": "Welcome to Normal Rooms",
+          "url": "../blog/post.html?slug=welcome"
+        },
+        {
+          "label": "Log",
+          "title": "NR-LAB-004 landing gate study",
+          "url": "../../lab/landing-gate-usability.html"
+        }
       ]
     },
     {
@@ -51,12 +81,27 @@
       "sequence": 1,
       "summary": "Maintain a calm gray-and-orange entry point that sets the tone while keeping access frictionless across devices.",
       "updated": "2024-04-29",
-      "tags": ["ux", "workflow"],
+      "tags": [
+        "ux",
+        "workflow"
+      ],
       "contentPath": "content/projects/landing-experience-refresh.html",
       "spotlight": [
-        {"label": "Wiki", "title": "Normal Rooms overview", "url": "../wiki/article.html?doc=normal-rooms"},
-        {"label": "Blog", "title": "Lab index release", "url": "../blog/post.html?slug=lab-index-release"},
-        {"label": "Log", "title": "NR-LAB-004 landing gate study", "url": "../../lab/landing-gate-usability.html"}
+        {
+          "label": "Wiki",
+          "title": "Normal Rooms overview",
+          "url": "../wiki/article.html?doc=normal-rooms"
+        },
+        {
+          "label": "Blog",
+          "title": "Lab index release",
+          "url": "../blog/post.html?slug=lab-index-release"
+        },
+        {
+          "label": "Log",
+          "title": "NR-LAB-004 landing gate study",
+          "url": "../../lab/landing-gate-usability.html"
+        }
       ]
     }
   ]

--- a/data/search/index.json
+++ b/data/search/index.json
@@ -1,92 +1,119 @@
 [
   {
-    "title": "Foundations",
-    "description": "Core principles behind the Normal Rooms static site.",
-    "url": "modules/wiki/index.html#foundations",
-    "tags": ["wiki", "architecture", "workflow"]
-  },
-  {
-    "title": "Architecture",
-    "description": "How the Docusaurus-inspired structure keeps content consistent.",
-    "url": "modules/wiki/index.html#architecture",
-    "tags": ["wiki", "static", "projects"]
-  },
-  {
-    "title": "Publishing workflow",
-    "description": "Single-source Markdown pipeline with static search indexing.",
-    "url": "modules/wiki/index.html#publishing",
-    "tags": ["wiki", "build", "quality"]
-  },
-  {
-    "title": "Governance",
-    "description": "Tag management and process alignment for Normal Rooms.",
-    "url": "modules/wiki/index.html#governance",
-    "tags": ["wiki", "governance", "process"]
+    "title": "Aligning static workflows with research cadence",
+    "description": "Synchronizing lab entries with wiki and project updates.",
+    "url": "modules/blog/post.html?slug=aligning-static-workflows",
+    "tags": [
+      "blog",
+      "workflow",
+      "lab"
+    ]
   },
   {
     "title": "Architecture overview",
     "description": "How modules, content, and assets compose the static knowledge base.",
     "url": "modules/wiki/article.html?doc=architecture-overview",
-    "tags": ["wiki", "architecture", "reference"]
-  },
-  {
-    "title": "Publishing checklist",
-    "description": "Step-by-step guide for preparing documentation releases.",
-    "url": "modules/wiki/article.html?doc=publishing-checklist",
-    "tags": ["wiki", "workflow", "quality"]
-  },
-  {
-    "title": "Aligning static workflows with research cadence",
-    "description": "Synchronizing lab entries with wiki and project updates.",
-    "url": "modules/blog/post.html?slug=aligning-static-workflows",
-    "tags": ["blog", "workflow", "lab"]
-  },
-  {
-    "title": "Publishing the first unified lab index",
-    "description": "Launching the lab notebook index and static search payload.",
-    "url": "modules/blog/post.html?slug=lab-index-release",
-    "tags": ["blog", "lab", "quality"]
-  },
-  {
-    "title": "Welcome to Normal Rooms",
-    "description": "Introducing the knowledge hub and gated landing page.",
-    "url": "modules/blog/post.html?slug=welcome",
-    "tags": ["blog", "announcement"]
-  },
-  {
-    "title": "NR-LAB-006 · Delta observation window stress test",
-    "description": "Stress testing the delta visualization during rapid rebuilds.",
-    "url": "lab/delta-observation-window.html",
-    "tags": ["lab", "performance"]
-  },
-  {
-    "title": "Project log · Static pipeline hardening (NR-LAB-005)",
-    "description": "Benchmarking latency for the static search index as part of the infrastructure sequence.",
-    "url": "modules/projects/project.html?slug=static-pipeline-hardening",
-    "tags": ["project", "search", "quality"]
-  },
-  {
-    "title": "Project log · Landing gate usability (NR-LAB-004)",
-    "description": "Testing the clarity and tone of the entry experience within the experience domain.",
-    "url": "modules/projects/project.html?slug=landing-experience-refresh",
-    "tags": ["project", "ux", "workflow"]
-  },
-  {
-    "title": "Static pipeline hardening",
-    "description": "Project hub connecting build improvements across idioms.",
-    "url": "modules/projects/project.html?slug=static-pipeline-hardening",
-    "tags": ["project", "build", "quality"]
+    "tags": [
+      "wiki",
+      "architecture",
+      "reference"
+    ]
   },
   {
     "title": "Knowledge graph curation",
     "description": "Taxonomy stewardship for tags, projects, and experiments.",
     "url": "modules/projects/project.html?slug=knowledge-graph-curation",
-    "tags": ["project", "governance", "workflow"]
+    "tags": [
+      "project",
+      "governance",
+      "workflow"
+    ]
   },
   {
     "title": "Landing experience refresh",
     "description": "Maintaining the gray-and-orange gate experience.",
     "url": "modules/projects/project.html?slug=landing-experience-refresh",
-    "tags": ["project", "ux", "announcement"]
+    "tags": [
+      "project",
+      "ux",
+      "workflow"
+    ]
+  },
+  {
+    "title": "Normal Rooms",
+    "description": "Overview of the Normal Rooms documentation stack and navigation patterns.",
+    "url": "modules/wiki/article.html?doc=normal-rooms",
+    "tags": [
+      "wiki",
+      "architecture",
+      "workflow"
+    ]
+  },
+  {
+    "title": "NR-LAB-004 · Landing gate usability study",
+    "description": "Testing the clarity and tone of the landing gate experience.",
+    "url": "lab/landing-gate-usability.html",
+    "tags": [
+      "lab",
+      "ux",
+      "workflow"
+    ]
+  },
+  {
+    "title": "NR-LAB-005 · Client-side search prototype benchmark",
+    "description": "Benchmarking latency for the static search prototype.",
+    "url": "lab/search-prototype-benchmark.html",
+    "tags": [
+      "lab",
+      "search"
+    ]
+  },
+  {
+    "title": "NR-LAB-006 · Delta observation window stress test",
+    "description": "Stress testing the delta visualization during rapid rebuilds.",
+    "url": "lab/delta-observation-window.html",
+    "tags": [
+      "lab",
+      "performance"
+    ]
+  },
+  {
+    "title": "Publishing checklist",
+    "description": "Step-by-step guide for preparing documentation releases.",
+    "url": "modules/wiki/article.html?doc=publishing-checklist",
+    "tags": [
+      "wiki",
+      "workflow",
+      "quality"
+    ]
+  },
+  {
+    "title": "Publishing the first unified lab index",
+    "description": "Launching the lab notebook index and static search payload.",
+    "url": "modules/blog/post.html?slug=lab-index-release",
+    "tags": [
+      "blog",
+      "lab",
+      "quality"
+    ]
+  },
+  {
+    "title": "Static pipeline hardening",
+    "description": "Project hub connecting build improvements across idioms.",
+    "url": "modules/projects/project.html?slug=static-pipeline-hardening",
+    "tags": [
+      "project",
+      "build",
+      "quality"
+    ]
+  },
+  {
+    "title": "Welcome to Normal Rooms",
+    "description": "Introducing the Normal Rooms knowledge hub and its documentation idioms.",
+    "url": "modules/blog/post.html?slug=welcome",
+    "tags": [
+      "blog",
+      "announcement"
+    ]
   }
 ]

--- a/data/wiki/articles.json
+++ b/data/wiki/articles.json
@@ -1,20 +1,20 @@
 {
   "articles": [
     {
-      "id": "normal-rooms",
-      "title": "Normal Rooms",
-      "subtitle": "Static-first knowledge base",
-      "summary": "Overview of the Normal Rooms documentation stack and navigation patterns.",
-      "contentPath": "content/wiki/normal-rooms.html",
-      "updated": "2024-05-24"
-    },
-    {
       "id": "architecture-overview",
       "title": "Architecture overview",
       "subtitle": "Technical reference",
       "summary": "How the static modules, assets, and content directories compose the site.",
       "contentPath": "content/wiki/architecture-overview.html",
       "updated": "2024-05-20"
+    },
+    {
+      "id": "normal-rooms",
+      "title": "Normal Rooms",
+      "subtitle": "Static-first knowledge base",
+      "summary": "Overview of the Normal Rooms documentation stack and navigation patterns.",
+      "contentPath": "content/wiki/normal-rooms.html",
+      "updated": "2024-05-24"
     },
     {
       "id": "publishing-checklist",

--- a/donate.html
+++ b/donate.html
@@ -4,12 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Normal Rooms · Support</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="assets/css/base.css" />
 </head>
 <body>

--- a/home.html
+++ b/home.html
@@ -4,12 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Normal Rooms · Home</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="assets/css/base.css" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,12 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Normal Rooms</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="assets/css/base.css" />
 </head>
 <body class="landing">

--- a/lab/delta-observation-window.html
+++ b/lab/delta-observation-window.html
@@ -1,15 +1,26 @@
+<!--
+{
+  "title": "NR-LAB-006 · Delta observation window stress test",
+  "summary": "Stress testing the delta visualization during rapid rebuilds of the static site.",
+  "surfaces": {
+    "lab": {
+      "id": "nr-lab-006",
+      "published": "2024-05-28",
+      "url": "lab/delta-observation-window.html"
+    },
+    "search": {
+      "description": "Stress testing the delta visualization during rapid rebuilds.",
+      "tags": ["lab", "performance"]
+    }
+  }
+}
+-->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>NR-LAB-006 · Delta observation window stress test · Normal Rooms</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="../assets/css/base.css" />
 </head>
 <body>

--- a/lab/landing-gate-usability.html
+++ b/lab/landing-gate-usability.html
@@ -1,15 +1,26 @@
+<!--
+{
+  "title": "NR-LAB-004 · Landing gate usability study",
+  "summary": "Observing how people navigate the landing gate and documenting friction that impacts the experience domain.",
+  "surfaces": {
+    "lab": {
+      "id": "nr-lab-004",
+      "published": "2024-05-12",
+      "url": "lab/landing-gate-usability.html"
+    },
+    "search": {
+      "description": "Testing the clarity and tone of the landing gate experience.",
+      "tags": ["lab", "ux", "workflow"]
+    }
+  }
+}
+-->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>NR-LAB-004 · Landing gate usability scan · Normal Rooms</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="../assets/css/base.css" />
 </head>
 <body>

--- a/lab/search-prototype-benchmark.html
+++ b/lab/search-prototype-benchmark.html
@@ -1,15 +1,26 @@
+<!--
+{
+  "title": "NR-LAB-005 · Client-side search prototype benchmark",
+  "summary": "Benchmarking the client-side search prototype to establish baseline performance for the static site.",
+  "surfaces": {
+    "lab": {
+      "id": "nr-lab-005",
+      "published": "2024-05-22",
+      "url": "lab/search-prototype-benchmark.html"
+    },
+    "search": {
+      "description": "Benchmarking latency for the static search prototype.",
+      "tags": ["lab", "search"]
+    }
+  }
+}
+-->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>NR-LAB-005 · Client-side search prototype benchmark · Normal Rooms</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="../assets/css/base.css" />
 </head>
 <body>

--- a/legal.html
+++ b/legal.html
@@ -4,12 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Normal Rooms · Legal</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="assets/css/base.css" />
 </head>
 <body>

--- a/modules/blog/index.html
+++ b/modules/blog/index.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Normal Rooms · Blog</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="../../assets/css/base.css" />
     <link rel="stylesheet" href="../../assets/css/modules.css" />
     <link rel="stylesheet" href="../../assets/css/blog.css" />

--- a/modules/blog/post.html
+++ b/modules/blog/post.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Normal Rooms · Blog post</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="../../assets/css/base.css" />
     <link rel="stylesheet" href="../../assets/css/modules.css" />
     <link rel="stylesheet" href="../../assets/css/blog.css" />

--- a/modules/projects/index.html
+++ b/modules/projects/index.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Normal Rooms · Projects</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Linux+Libertine:wght@400;700&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="../../assets/css/base.css" />
     <link rel="stylesheet" href="../../assets/css/modules.css" />
     <link rel="stylesheet" href="../../assets/css/projects.css" />

--- a/modules/projects/project.html
+++ b/modules/projects/project.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Normal Rooms · Project</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Linux+Libertine:wght@400;700&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="../../assets/css/base.css" />
     <link rel="stylesheet" href="../../assets/css/modules.css" />
     <link rel="stylesheet" href="../../assets/css/projects.css" />

--- a/modules/wiki/article.html
+++ b/modules/wiki/article.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Normal Rooms · Wiki article</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Linux+Libertine:wght@400;700&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="../../assets/css/base.css" />
     <link rel="stylesheet" href="../../assets/css/modules.css" />
     <link rel="stylesheet" href="../../assets/css/wiki.css" />

--- a/modules/wiki/index.html
+++ b/modules/wiki/index.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Normal Rooms · Wiki</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Linux+Libertine:wght@400;700&family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="../../assets/css/base.css" />
     <link rel="stylesheet" href="../../assets/css/modules.css" />
     <link rel="stylesheet" href="../../assets/css/wiki.css" />

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "Static Normal Rooms website with automated smoke tests.",
   "type": "module",
   "scripts": {
+    "build:documents": "node scripts/build-documents.mjs",
+    "pretest": "npm run build:documents",
     "test": "npm run test:links && npm run test:index && npm run test:search && npm run test:navigation && npm run test:footer",
     "test:links": "node --test tests/link-health.test.mjs",
     "test:index": "node --test tests/search-index.test.mjs",

--- a/scripts/build-documents.mjs
+++ b/scripts/build-documents.mjs
@@ -1,0 +1,243 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+
+const contentRoots = [path.join(projectRoot, 'content'), path.join(projectRoot, 'lab')];
+
+const blogPosts = [];
+const wikiArticles = [];
+const projectEntries = [];
+const projectDomains = new Map();
+const searchEntries = [];
+
+await Promise.all(contentRoots.map((dir) => collectDocuments(dir)));
+
+writeOutputs().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+
+async function collectDocuments(dir) {
+  let entries = [];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectDocuments(entryPath);
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      await processDocument(entryPath);
+    }
+  }
+}
+
+async function processDocument(filePath) {
+  const raw = await fs.readFile(filePath, 'utf8');
+  const normalized = raw.replace(/^\uFEFF/, '');
+  const frontMatterMatch = normalized.match(/^<!--\s*\n?([\s\S]*?)\s*-->/);
+  if (!frontMatterMatch) {
+    return;
+  }
+
+  let meta;
+  try {
+    meta = JSON.parse(frontMatterMatch[1]);
+  } catch (error) {
+    throw new Error(`Invalid front matter in ${path.relative(projectRoot, filePath)}: ${error.message}`);
+  }
+
+  if (!meta || typeof meta !== 'object') {
+    return;
+  }
+
+  const surfaces = meta.surfaces ?? {};
+  if (!surfaces || typeof surfaces !== 'object') {
+    return;
+  }
+
+  const relativePath = path.relative(projectRoot, filePath).split(path.sep).join('/');
+  const slugFromFile = path.basename(filePath, path.extname(filePath));
+
+  if (surfaces.blog) {
+    const blogConfig = surfaces.blog;
+    const slug = blogConfig.slug ?? meta.slug ?? slugFromFile;
+    if (!blogConfig.date) {
+      throw new Error(`Blog document ${relativePath} is missing a publication date.`);
+    }
+    blogPosts.push({
+      slug,
+      title: blogConfig.title ?? meta.title ?? slug,
+      date: blogConfig.date,
+      type: blogConfig.type ?? 'Update',
+      summary: blogConfig.summary ?? meta.summary ?? '',
+      contentPath: relativePath,
+      tags: Array.isArray(blogConfig.tags) ? blogConfig.tags : Array.isArray(meta.tags) ? meta.tags : [],
+    });
+  }
+
+  if (surfaces.wiki) {
+    const wikiConfig = surfaces.wiki;
+    const id = wikiConfig.id ?? meta.id ?? slugFromFile;
+    wikiArticles.push({
+      id,
+      title: wikiConfig.title ?? meta.title ?? id,
+      subtitle: wikiConfig.subtitle ?? meta.subtitle ?? '',
+      summary: wikiConfig.summary ?? meta.summary ?? '',
+      contentPath: relativePath,
+      updated: wikiConfig.updated ?? meta.updated ?? '',
+    });
+  }
+
+  if (surfaces.projects) {
+    const projectConfig = surfaces.projects;
+    const slug = projectConfig.slug ?? meta.slug ?? slugFromFile;
+    const domainConfig = normalizeDomain(projectConfig.domain);
+    const existingDomain = projectDomains.get(domainConfig.name);
+    if (!existingDomain) {
+      projectDomains.set(domainConfig.name, domainConfig);
+    } else {
+      const merged = {
+        name: domainConfig.name,
+        description: domainConfig.description || existingDomain.description,
+        order: Number.isFinite(domainConfig.order) ? domainConfig.order : existingDomain.order,
+      };
+      projectDomains.set(domainConfig.name, merged);
+    }
+
+    projectEntries.push({
+      slug,
+      title: projectConfig.title ?? meta.title ?? slug,
+      domain: domainConfig.name,
+      sequence: projectConfig.sequence ?? null,
+      summary: projectConfig.summary ?? meta.summary ?? '',
+      updated: projectConfig.updated ?? meta.updated ?? '',
+      tags: Array.isArray(projectConfig.tags)
+        ? projectConfig.tags
+        : Array.isArray(meta.tags)
+        ? meta.tags
+        : [],
+      contentPath: relativePath,
+      spotlight: Array.isArray(projectConfig.spotlight) ? projectConfig.spotlight : [],
+    });
+  }
+
+  if (surfaces.search) {
+    const searchConfig = surfaces.search;
+    const url =
+      searchConfig.url ??
+      inferUrl({
+        relativePath,
+        slugFromFile,
+        meta,
+        surfaces,
+      });
+    searchEntries.push({
+      title: searchConfig.title ?? meta.title ?? slugFromFile,
+      description: searchConfig.description ?? meta.summary ?? '',
+      url,
+      tags: Array.isArray(searchConfig.tags)
+        ? searchConfig.tags
+        : Array.isArray(meta.tags)
+        ? meta.tags
+        : [],
+    });
+  }
+}
+
+function normalizeDomain(input) {
+  if (!input) {
+    return { name: 'General', description: '', order: Number.MAX_SAFE_INTEGER };
+  }
+  if (typeof input === 'string') {
+    return { name: input, description: '', order: Number.MAX_SAFE_INTEGER };
+  }
+  return {
+    name: input.name ?? 'General',
+    description: input.description ?? '',
+    order: Number.isFinite(Number(input.order)) ? Number(input.order) : Number.MAX_SAFE_INTEGER,
+  };
+}
+
+function inferUrl({ relativePath, slugFromFile, meta, surfaces }) {
+  if (surfaces.blog) {
+    const slug = surfaces.blog.slug ?? meta.slug ?? slugFromFile;
+    return `modules/blog/post.html?slug=${slug}`;
+  }
+  if (surfaces.wiki) {
+    const id = surfaces.wiki.id ?? meta.id ?? slugFromFile;
+    return `modules/wiki/article.html?doc=${id}`;
+  }
+  if (surfaces.projects) {
+    const slug = surfaces.projects.slug ?? meta.slug ?? slugFromFile;
+    return `modules/projects/project.html?slug=${slug}`;
+  }
+  if (surfaces.lab && surfaces.lab.url) {
+    return surfaces.lab.url;
+  }
+  return relativePath;
+}
+
+async function writeOutputs() {
+  blogPosts.sort((a, b) => new Date(b.date) - new Date(a.date));
+  wikiArticles.sort((a, b) => a.title.localeCompare(b.title));
+  projectEntries.sort((a, b) => {
+    const domainOrderA = projectDomains.get(a.domain)?.order ?? Number.MAX_SAFE_INTEGER;
+    const domainOrderB = projectDomains.get(b.domain)?.order ?? Number.MAX_SAFE_INTEGER;
+    if (domainOrderA !== domainOrderB) {
+      return domainOrderA - domainOrderB;
+    }
+    if (a.domain !== b.domain) {
+      return a.domain.localeCompare(b.domain);
+    }
+    if (a.sequence !== b.sequence) {
+      if (a.sequence == null) return 1;
+      if (b.sequence == null) return -1;
+      return a.sequence - b.sequence;
+    }
+    return a.title.localeCompare(b.title);
+  });
+  searchEntries.sort((a, b) => a.title.localeCompare(b.title));
+
+  const domainsObject = {};
+  Array.from(projectDomains.values())
+    .sort((a, b) => {
+      if (a.order !== b.order) {
+        return a.order - b.order;
+      }
+      return a.name.localeCompare(b.name);
+    })
+    .forEach((domain) => {
+      domainsObject[domain.name] = {
+        description: domain.description,
+        order: Number.isFinite(domain.order) ? domain.order : undefined,
+      };
+      if (domainsObject[domain.name].order === undefined) {
+        delete domainsObject[domain.name].order;
+      }
+    });
+
+  await Promise.all([
+    writeJson(['data', 'blog', 'posts.json'], { posts: blogPosts }),
+    writeJson(['data', 'wiki', 'articles.json'], { articles: wikiArticles }),
+    writeJson(['data', 'projects', 'projects.json'], { domains: domainsObject, projects: projectEntries }),
+    writeJson(['data', 'search', 'index.json'], searchEntries),
+  ]);
+}
+
+async function writeJson(segments, data) {
+  const targetPath = path.join(projectRoot, ...segments);
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  const payload = JSON.stringify(data, null, 2);
+  await fs.writeFile(targetPath, `${payload}\n`, 'utf8');
+}

--- a/search.html
+++ b/search.html
@@ -4,12 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Normal Rooms · Search</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="assets/css/base.css" />
 </head>
 <body>

--- a/tags.html
+++ b/tags.html
@@ -4,12 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Normal Rooms · Tags</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
-    rel="stylesheet"
-  />
   <link rel="stylesheet" href="assets/css/base.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add JSON front matter to documentation fragments and add a build script that populates the blog, wiki, project, and search indexes from that metadata
- refresh contributor documentation so adding a page only requires dropping an HTML file with front matter into the content folders
- normalize global styling by sourcing fonts from base.css and removing module-specific font overrides for a consistent look across the site

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fed2543344832b8a32fe5a4297f0f8